### PR TITLE
only show contacts with display names; fixes #5

### DIFF
--- a/hangups/client.py
+++ b/hangups/client.py
@@ -442,7 +442,8 @@ class Client(object):
                 # found via the other methods.
                 # TODO We should note who these users are and try to request
                 # them.
-                if len(p) > 1:
+                # for some contats, p[1] is None??
+                if len(p) > 1 and p[1]:
                     display_name = p[1]
                     self.initial_users[user_id] = User(
                         id_=user_id, first_name=display_name.split()[0],


### PR DESCRIPTION
some contacts have `None` for their display name, this commit addresses
this by only showing contacts with truthy display name values. looks
like this contact code is temporary, but at least this fixes this issue
for now
