### PR TITLE
Validate input username

### DIFF
--- a/hangups/auth.py
+++ b/hangups/auth.py
@@ -185,13 +185,24 @@ def get_auth_stdin(cookie_filename):
     """Wrapper for get_auth that prompts the user on stdin."""
     def get_credentials_f():
         """Prompt for and return credentials."""
-        email = input('Email: ')
+        email = validate_input_email()
         password = getpass.getpass()
         return (email, password)
     def get_pin_f():
         """Prompt for and return PIN."""
         return input('PIN: ')
     return get_auth(get_credentials_f, get_pin_f, cookie_filename)
+
+
+def validate_input_email():
+    while True:
+        username = input('Username: ')
+        if "gmail.com" in username:
+            print('Invalid Google username.')
+        else:
+            break
+
+    return username
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Greetings,

This is commit addresses #35.  I added a method to validate the username coming in to make sure the google username is used instead.

If the user has a google apps domain (something like `jstudent@my.wheaton.edu`), the full username should be used.  Basically, just checks the string for `@gmail.com`.  Same rules as logging into gmail.

Let me know if I'm missing something or not following your standards.  This was just an impulsive commit to a project I _just_ found.  I would love to work on this and help out.  I love hangouts, but the Google client looks like crap in tiling WMs.
