### PR TITLE
Updated integer regexp to allow for negatives

### DIFF
--- a/hangups/javascript.py
+++ b/hangups/javascript.py
@@ -73,8 +73,7 @@ def _unescape_string(s):
 
 class JavaScriptLexer(purplex.Lexer):
     """Lexer for a subset of JavaScript."""
-    # TODO: Negative integers
-    INTEGER = purplex.TokenDef(r'\d+')
+    INTEGER = purplex.TokenDef(r'[+-]?(?<!\.)\b[0-9]+\b(?!\.[0-9])')
     FLOAT = purplex.TokenDef(r'[-+]?\d*[.]\d+')
 
     NULL = purplex.TokenDef(r'null')

--- a/hangups/test/test_javascript.py
+++ b/hangups/test/test_javascript.py
@@ -8,6 +8,7 @@ from hangups import javascript
 @pytest.mark.parametrize('input_,expected', [
     # simple types
     ('12', 12),
+    ('-1', -1),
     ('null', None),
     ('true', True),
     ('false', False),


### PR DESCRIPTION
Found this while looking for TODOs

Implemented [this](http://stackoverflow.com/questions/16774064/regular-expression-for-whole-numbers-and-integers) pattern instead.  Added a unit test and it seems to be working.
