### PR TITLE
Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ python:
     - '3.4'
 install:
     - python setup.py install
+    - python setup.py install test
 script:
-    - python setup.py --quiet test
+    - coverage run --source=hangups setup.py test
     - pip install --quiet docutils
     - python setup.py check --metadata --restructuredtext --strict
+after_success:
+    - coveralls

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ hangups
     :target: https://readthedocs.org/projects/hangups/?badge=latest
     :alt: Documentation Status
 
+.. image:: https://coveralls.io/repos/tdryer/hangups/badge.png
+    :target: https://coveralls.io/r/tdryer/hangups
+    :alt: Test Coverage
+
 hangups is the first third-party instant messaging client for `Google
 Hangouts`_. It includes both a Python library and a reference client with a
 text-based user interface.

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,11 @@ setup(
         'hangups-urwid==1.2.2-dev',
         # Backports for py3.3:
         'enum34==1.0',
-        'asyncio==3.4.1',
+        'asyncio==3.4.1'
     ],
     tests_require=[
         'pytest',
+        'coveralls==0.4.4'
     ],
     cmdclass={'test': PyTest},
     entry_points={


### PR DESCRIPTION
This commit is for [coveralls](https://coveralls.io) integration.  If it not needed, just close the request.

@tdryer will have to enable it for the repository.  It's already tied to Travis, so that will be the only thing needed to be done.

It will analyze the `hangups` package for unit test coverage and output the results in the badge I added to the README.
