### PR TITLE
Fix missing link targets in some messages

### DIFF
--- a/hangups/conversation_event.py
+++ b/hangups/conversation_event.py
@@ -99,10 +99,15 @@ class ChatMessageSegment(object):
             is_italic = bool(segment.formatting.italic)
             is_strikethrough = bool(segment.formatting.strikethrough)
             is_underline = bool(segment.formatting.underline)
+        if segment.link_data is None:
+            link_target = None
+        else:
+            link_target = segment.link_data.link_target
         return ChatMessageSegment(
             segment.text, segment_type=segment.type_,
             is_bold=is_bold, is_italic=is_italic,
             is_strikethrough=is_strikethrough, is_underline=is_underline,
+            link_target=link_target
         )
 
     def serialize(self):


### PR DESCRIPTION
I am updating QHangups and I have discovered that link_target isn't set. So here is quick fix...