### PR TITLE
force group chat creation with optional createconversation() parameter

### DIFF
--- a/hangups/client.py
+++ b/hangups/client.py
@@ -709,7 +709,7 @@ class Client(object):
 
 
     @asyncio.coroutine
-    def createconversation(self, chat_id_list):
+    def createconversation(self, chat_id_list, force_group = False):
         """Create new conversation.
 
         conversation_id must be a valid conversation ID.
@@ -723,7 +723,7 @@ class Client(object):
         client_generated_id = random.randint(0, 2**32)
         body = [
             self._get_request_header(),
-            1 if len(chat_id_list) == 1 else 2,
+            1 if len(chat_id_list) == 1 and not force_group else 2,
             client_generated_id,
             None,
             [[str(chat_id), None, None, "unknown", None, []]


### PR DESCRIPTION
`createconversation` always defaults to creating a 1-to-1 conversation when only a single chat id is supplied - `force_group = True` to create a group instead: useful for creating a 2-members group to add other users in at a later time. note: the hangouts server differentiates 1-to-1 and group chats, and additional users cannot be added into a 1-to-1 after creation 

cc: @xmikos 
