### PR TITLE
Add optional image_id parameter to Conversation.send_message method

### DIFF
--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -89,13 +89,17 @@ class Conversation(object):
         return self._user_list.get_user(user_id)
 
     @asyncio.coroutine
-    def send_message(self, segments, image_file=None):
+    def send_message(self, segments, image_file=None, image_id=None):
         """Send a message to this conversation.
 
         segments is a list of ChatMessageSegments to include in the message.
 
         image_file is an optional file-like object containing an image to be
         attached to the message.
+
+        image_id is an optional ID of an image to be attached to the message
+        (if you specify both image_file and image_id together, image_file
+        takes precedence and supplied image_id will be ignored)
 
         Raises hangups.NetworkError if the message can not be sent.
         """
@@ -109,8 +113,6 @@ class Conversation(object):
             except exceptions.NetworkError as e:
                 logger.warning('Failed to upload image: {}'.format(e))
                 raise
-        else:
-            image_id = None
         try:
             yield from self._client.sendchatmessage(
                 self.id_, [seg.serialize() for seg in segments],


### PR DESCRIPTION
As I already commented in your commit: There still needs to be possibility to send image by its G+ image_id (not only by image_file). It's needed for forwarding of image messages and I also plan to add possibility to select image from users G+ account to my QHangups client. I can use client.sendchatmessage directly, but it seems wrong, this should be in conversation.send_message.