### PR TITLE
ReParser for parsing text into ChatMessageSegments

### DIFF
--- a/hangups/message_parser.py
+++ b/hangups/message_parser.py
@@ -1,0 +1,76 @@
+import re
+
+from reparser import Parser, Token, MatchGroup
+from hangups.schemas import SegmentType
+
+
+# Common regex patterns
+boundary_chars = r'\s`!()\[\]{{}};:\'".,<>?«»“”‘’'
+b_left = r'(?:(?<=[' + boundary_chars + r'])|(?<=^))' # Lookbehind
+b_right = r'(?:(?=[' + boundary_chars + r'])|(?=$))' # Lookahead
+
+# Regex patterns used by token definitions
+markdown = b_left + r'(?P<start>{tag})(?P<text>\S.+?\S)(?P<end>{tag})' + b_right
+markdown_link = r'(?P<start>\[)(?P<text>.+?)\]\((?P<url>.+?)(?P<end>\))'
+html = r'(?i)(?P<start><{tag}>)(?P<text>.+?)(?P<end></{tag}>)'
+html_link = r'(?i)(?P<start><a href=[\'"](?P<url>.+?)[\'"]>)(?P<text>.+?)(?P<end></a>)'
+html_img = r'(?i)(?P<text><img src=[\'"](?P<url>.+?)[\'"](\s*/)?>)'
+html_newline = r'(?i)(?P<text><br(\s*/)?>)'
+newline = r'(?P<text>\n|\r\n)'
+
+# Based on URL regex pattern by John Gruber (http://gist.github.com/gruber/249502)
+auto_link = (r'(?i)\b(?P<text>'
+             r'(?:[a-z][\w-]+:/{1,3}|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)'
+             r'(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+'
+             r'(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))')
+
+url_proto_re = re.compile(r'(?i)^[a-z][\w-]+:/{1,3}')
+url_complete = lambda u: u if url_proto_re.search(u) else 'http://' + u
+
+class Tokens:
+    """Groups of tokens to be used by ChatMessageParser"""
+    basic = [
+        Token(auto_link, link_target=MatchGroup('text', func=url_complete)),
+        Token(newline, text='\n', segment_type=SegmentType.LINE_BREAK)
+    ]
+
+    markdown = [
+        Token(markdown.format(tag=r'\*\*\*'), is_bold=True, is_italic=True),
+        Token(markdown.format(tag=r'___'), is_bold=True, is_italic=True),
+        Token(markdown.format(tag=r'\*\*'), is_bold=True),
+        Token(markdown.format(tag=r'__'), is_bold=True),
+        Token(markdown.format(tag=r'\*'), is_italic=True),
+        Token(markdown.format(tag=r'_'), is_italic=True),
+        Token(markdown.format(tag=r'~~'), is_strikethrough=True),
+        Token(markdown.format(tag=r'=='), is_underline=True),
+        Token(markdown_link, link_target=MatchGroup('url', func=url_complete))
+    ]
+
+    html = [
+        Token(html.format(tag=r'b'), is_bold=True),
+        Token(html.format(tag=r'strong'), is_bold=True),
+        Token(html.format(tag=r'i'), is_italic=True),
+        Token(html.format(tag=r'em'), is_italic=True),
+        Token(html.format(tag=r's'), is_strikethrough=True),
+        Token(html.format(tag=r'strike'), is_strikethrough=True),
+        Token(html.format(tag=r'del'), is_strikethrough=True),
+        Token(html.format(tag=r'u'), is_underline=True),
+        Token(html.format(tag=r'ins'), is_underline=True),
+        Token(html.format(tag=r'mark'), is_underline=True),
+        Token(html_link, link_target=MatchGroup('url', func=url_complete)),
+        Token(html_img, text=MatchGroup('url', func=url_complete),
+              link_target=MatchGroup('url', func=url_complete)),
+        Token(html_newline, text='\n', segment_type=SegmentType.LINE_BREAK)
+    ]
+
+
+class ChatMessageParser(Parser):
+    """Chat message parser"""
+    def __init__(self, tokens=Tokens.markdown + Tokens.html + Tokens.basic):
+        super().__init__(tokens)
+
+    def preprocess(self, text):
+        """Preprocess text before parsing"""
+        # Replace two consecutive spaces with space and non-breakable space
+        # (this is how original Hangouts client does it to preserve multiple spaces)
+        return text.replace('  ', ' \xa0')

--- a/hangups/test/test_message_parser.py
+++ b/hangups/test/test_message_parser.py
@@ -1,0 +1,68 @@
+"""Tests for ReParser-based message parser"""
+
+import pytest
+
+from hangups import message_parser
+from hangups.schemas import SegmentType
+
+
+def parse_text(text):
+    parser = message_parser.ChatMessageParser()
+    return [(s.text, s.params) for s in parser.parse(text)]
+
+
+def test_parse_linebreaks():
+    text = 'line1\nline2\r\nline3'
+    expected = [('line1', {}),
+                ('\n', {'segment_type': SegmentType.LINE_BREAK}),
+                ('line2', {}),
+                ('\n', {'segment_type': SegmentType.LINE_BREAK}),
+                ('line3', {})]
+    assert expected == parse_text(text)
+
+
+def test_parse_autolinks():
+    text = 'www.google.com google.com/maps (https://en.wikipedia.org/wiki/Parenthesis_(disambiguation))'
+    expected = [('www.google.com', {'link_target': 'http://www.google.com'}),
+                (' ', {}),
+                ('google.com/maps', {'link_target': 'http://google.com/maps'}),
+                (' (', {}),
+                ('https://en.wikipedia.org/wiki/Parenthesis_(disambiguation)',
+                 {'link_target': 'https://en.wikipedia.org/wiki/Parenthesis_(disambiguation)'}),
+                (')', {})]
+    assert expected == parse_text(text)
+
+
+def test_parse_markdown():
+    text = 'Test **bold *bolditalic* bold** _italic_ not_italic_not ~~strike~~ [Google](www.google.com)'
+    expected = [('Test ', {}),
+                ('bold ', {'is_bold': True}),
+                ('bolditalic', {'is_bold': True, 'is_italic': True}),
+                (' bold', {'is_bold': True}),
+                (' ', {}),
+                ('italic', {'is_italic': True}),
+                (' not_italic_not ', {}),
+                ('strike', {'is_strikethrough': True}),
+                (' ', {}),
+                ('Google', {'link_target': 'http://www.google.com'})]
+    assert expected == parse_text(text)
+
+
+def test_parse_html():
+    text = ('Test <b>bold <i>bolditalic</i> bold</b> <em>italic</em> <del>strike</del>'
+            '<br>'
+            '<a href="google.com">Google</a>'
+            '<img src=\'https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg\'>')
+    expected = [('Test ', {}),
+                ('bold ', {'is_bold': True}),
+                ('bolditalic', {'is_bold': True, 'is_italic': True}),
+                (' bold', {'is_bold': True}),
+                (' ', {}),
+                ('italic', {'is_italic': True}),
+                (' ', {}),
+                ('strike', {'is_strikethrough': True}),
+                ('\n', {'segment_type': SegmentType.LINE_BREAK}),
+                ('Google', {'link_target': 'http://google.com'}),
+                ('https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg',
+                 {'link_target': 'https://upload.wikimedia.org/wikipedia/en/8/80/Wikipedia-logo-v2.svg'})]
+    assert expected == parse_text(text)

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'purplex==0.2.4',
         'requests==2.6.0',
         'robobrowser==0.5.2',
+        'ReParser>=1.2',
         # use forked urwid until there's a 1.3 release with colour bugfix
         'hangups-urwid==1.2.2-dev',
         # backport enum for python3.3:


### PR DESCRIPTION
Use ReParser (simple regex-based lexer/parser for inline markup)
written specifically for use in Hangups/HangupsBot for parsing text
into list of ChatMessageSegments (via ChatMessageSegment.from_str method).

Handles line breaks, URLs, simplified Markdown and HTML.

Supported Markdown tags:

    _, *, __, **, ~~, ==, [link](url)

Supported HTML tags:

    <a href="url">, <img src="url">, <b>, <strong>, <i>, <em>,
    <s>, <strike>, <del>, <u>, <ins>, <mark>, <br>