### PR TITLE
Update message_parser.py to properly support nested tags

### DIFF
--- a/hangups/message_parser.py
+++ b/hangups/message_parser.py
@@ -10,7 +10,7 @@ b_left = r'(?:(?<=[' + boundary_chars + r'])|(?<=^))' # Lookbehind
 b_right = r'(?:(?=[' + boundary_chars + r'])|(?=$))' # Lookahead
 
 # Regex patterns used by token definitions
-markdown = b_left + r'(?P<start>{tag})(?P<text>\S.+?\S)(?P<end>{tag})' + b_right
+markdown = b_left + r'(?P<start>{tag})(?!{tag})(?P<text>(?:\S.+?\S|\S+))(?<!{tag})(?P<end>{tag})' + b_right
 markdown_link = r'(?P<start>\[)(?P<text>.+?)\]\((?P<url>.+?)(?P<end>\))'
 html = r'(?i)(?P<start><{tag}>)(?P<text>.+?)(?P<end></{tag}>)'
 html_link = r'(?i)(?P<start><a href=[\'"](?P<url>.+?)[\'"]>)(?P<text>.+?)(?P<end></a>)'
@@ -30,8 +30,8 @@ url_complete = lambda u: u if url_proto_re.search(u) else 'http://' + u
 class Tokens:
     """Groups of tokens to be used by ChatMessageParser"""
     basic = [
-        Token(auto_link, link_target=MatchGroup('text', func=url_complete)),
-        Token(newline, text='\n', segment_type=SegmentType.LINE_BREAK)
+        Token(auto_link, final=True, link_target=MatchGroup('text', func=url_complete)),
+        Token(newline, text='\n', final=True, segment_type=SegmentType.LINE_BREAK)
     ]
 
     markdown = [
@@ -43,7 +43,7 @@ class Tokens:
         Token(markdown.format(tag=r'_'), is_italic=True),
         Token(markdown.format(tag=r'~~'), is_strikethrough=True),
         Token(markdown.format(tag=r'=='), is_underline=True),
-        Token(markdown_link, link_target=MatchGroup('url', func=url_complete))
+        Token(markdown_link, final=True, link_target=MatchGroup('url', func=url_complete))
     ]
 
     html = [
@@ -57,10 +57,10 @@ class Tokens:
         Token(html.format(tag=r'u'), is_underline=True),
         Token(html.format(tag=r'ins'), is_underline=True),
         Token(html.format(tag=r'mark'), is_underline=True),
-        Token(html_link, link_target=MatchGroup('url', func=url_complete)),
-        Token(html_img, text=MatchGroup('url', func=url_complete),
+        Token(html_link, final=True, link_target=MatchGroup('url', func=url_complete)),
+        Token(html_img, text=MatchGroup('url', func=url_complete), final=True,
               link_target=MatchGroup('url', func=url_complete)),
-        Token(html_newline, text='\n', segment_type=SegmentType.LINE_BREAK)
+        Token(html_newline, text='\n', final=True, segment_type=SegmentType.LINE_BREAK)
     ]
 
 

--- a/hangups/message_parser.py
+++ b/hangups/message_parser.py
@@ -6,8 +6,8 @@ from hangups.schemas import SegmentType
 
 # Common regex patterns
 boundary_chars = r'\s`!()\[\]{{}};:\'".,<>?«»“”‘’'
-b_left = r'(?:(?<=[' + boundary_chars + r'])|(?<=^))' # Lookbehind
-b_right = r'(?:(?=[' + boundary_chars + r'])|(?=$))' # Lookahead
+b_left = r'(?:(?<=[' + boundary_chars + r'])|(?<=^))'  # Lookbehind
+b_right = r'(?:(?=[' + boundary_chars + r'])|(?=$))'   # Lookahead
 
 # Regex patterns used by token definitions
 markdown = b_left + r'(?P<start>{tag})(?!{tag})(?P<text>(?:\S.+?\S|\S+))(?<!{tag})(?P<end>{tag})' + b_right
@@ -26,6 +26,7 @@ auto_link = (r'(?i)\b(?P<text>'
 
 url_proto_re = re.compile(r'(?i)^[a-z][\w-]+:/{1,3}')
 url_complete = lambda u: u if url_proto_re.search(u) else 'http://' + u
+
 
 class Tokens:
     """Groups of tokens to be used by ChatMessageParser"""

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'purplex==0.2.4',
         'requests==2.6.0',
         'robobrowser==0.5.2',
-        'ReParser>=1.2',
+        'ReParser>=1.3',
         # use forked urwid until there's a 1.3 release with colour bugfix
         'hangups-urwid==1.2.2-dev',
         # backport enum for python3.3:


### PR DESCRIPTION
This change is needed for proper support of nested tags (both Markdown and HTML). I have also upgraded ReParser (now it works recursively) and this change is backward incompatible, so dependency in Hangups should be changed to ReParser>=1.3 (change is included in pull request).

This has been tested manually and with HangupsBot and everything seems to work right.

Performance is worse, very long messages (50 kB) with combined Markdown and HTML syntax took on my laptop about 1.5 s to be parsed (but small messages are really fast). There is room for optimizations, but it will take some time till I get to it.