### PR TITLE
Use OAuth2.0 for authenication

### DIFF
--- a/hangups/auth.py
+++ b/hangups/auth.py
@@ -1,22 +1,23 @@
-"""Simple Google auth supporting second factor.
+""" Google auth using OAuth2.0
 
-This module should not log user credentials.
+This module logs the refresh_token, which can be revoked from
+ https://security.google.com/settings/security/permissions.
+The authorization is shown as "iOS device".
 
 This code may be debugged by invoking it directly:
     python -m hangups.auth
 """
 
-import robobrowser
 import requests
 import logging
 import getpass
 import json
 
-
 logger = logging.getLogger(__name__)
-LOGIN_URL = 'https://accounts.google.com/ServiceLogin'
-SECONDFACTOR_URL = 'https://accounts.google.com/SecondFactor'
 
+OAUTH2_LOGIN_URL='https://accounts.google.com/o/oauth2/auth?scope=https://www.google.com/accounts/OAuthLogin%20https://www.googleapis.com/auth/userinfo.email&redirect_uri=urn:ietf:wg:oauth:2.0:oob&response_type=code&client_id=936475272427.apps.googleusercontent.com'
+CLIENT_ID = '936475272427.apps.googleusercontent.com'
+CLIENT_SECRET = 'KWsJlkaMn1jGLxQpWxMnOox-'
 
 class GoogleAuthError(Exception):
 
@@ -32,121 +33,86 @@ def _extract_cookies(session):
     cookies = session.cookies._cookies_for_request(mock_req)
     return {c.name: c.value for c in cookies}
 
-
-def _load_cookies(cookie_filename):
-    """Return cookies loaded from file or None on failure."""
-    logger.info('Attempting to load auth cookies from {}'
-                .format(cookie_filename))
+def _load_oauth2_refresh_token(oauth2_refresh_token_filename):
+    """Return refresh_token loaded from file or None on failure."""
+    logger.info('Attempting to load refresh_token from {}'
+                .format(oauth2_refresh_token_filename))
     try:
-        with open(cookie_filename) as f:
-            cookies = json.load(f)
-            # TODO: Verify that the saved cookies are still valid and ignore
-            # them if they are not.
-            logger.info('Using saved auth cookies')
-            return cookies
+        with open(oauth2_refresh_token_filename) as f:
+            refresh_token = f.read()
+            logger.info('Using saved refresh_token: {}'.format(refresh_token))
+            return refresh_token
     except (IOError, ValueError):
-        logger.info('Failed to load saved auth cookies')
+        logger.info('Failed to load saved refresh_token')
 
-
-def _save_cookies(cookie_filename, cookies):
-    """Save cookies to file, ignoring failure."""
-    logger.info('Attempting to save auth cookies to {}'
-                .format(cookie_filename))
+def _save_oauth2_refresh_token(oauth2_refresh_token_filename, refresh_token):
+    """Save refresh_token to file, ignoring failure."""
+    logger.info('Attempting to save auth refresh_token to {}'
+                .format(oauth2_refresh_token_filename))
     try:
-        with open(cookie_filename, 'w') as f:
-            json.dump(cookies, f)
-        logger.info('Auth cookies saved')
+        with open(oauth2_refresh_token_filename, 'w') as f:
+            f.write(refresh_token)
+        logger.info('refresh_token saved')
     except IOError as e:
-        logger.warning('Failed to save auth cookies: {}'.format(e))
-    return cookies
+        logger.warning('Failed to save refresh_token: {}'.format(e))
+    return refresh_token
 
-
-def _login(get_credentials_f, get_pin_f):
-    """Login to Google and return logged in session."""
-    logger.info('Starting Google login...')
-    browser = robobrowser.RoboBrowser()
-
-    browser.open(LOGIN_URL)
-    if browser.response.status_code != 200:
-        raise GoogleAuthError('Login form returned code {}'
-                              .format(browser.response.status_code))
-    form = browser.get_form(id='gaia_loginform')
-    if form is None:
-        raise GoogleAuthError('Failed to find login form')
-    email, password = get_credentials_f()
-    try:
-        form['Email'] = email
-    except KeyError:
-        raise GoogleAuthError('Failed to find email field')
-    try:
-        form['Passwd'] = password
-    except KeyError:
-        raise GoogleAuthError('Failed to find password field')
-    logger.info('Submitting login form...')
-    browser.submit_form(form)
-
-    if browser.response.url == SECONDFACTOR_URL:
-        logger.info('Login requires second factor')
-        form = browser.get_form(id='gaia_secondfactorform')
-        if form is None:
-            raise GoogleAuthError('Failed to find secondfactor form')
-        pin = get_pin_f()
-        try:
-            form['smsUserPin'] = pin
-        except KeyError:
-            raise GoogleAuthError('Failed to find second factor PIN field')
-        logger.info('Submitting second factor form...')
-        try:
-            # The form contains multiple submit inputs, so we need to specify
-            # the correct one.
-            browser.submit_form(form, submit=form['smsVerifyPin'])
-        except KeyError:
-            raise GoogleAuthError(
-                'Failed to find second factor submission field')
-    else:
-        logger.info('Login does not require second factor')
-
-    # Verify that the login was successful by checking the presence of a
-    # cookie.
-    if 'SSID' not in _extract_cookies(browser.session):
-        raise GoogleAuthError('Login failed')
-    return browser.session
-
-
-def get_auth(get_credentials_f, get_pin_f, cookie_filename):
-    """Login into Google and return cookies as a dict.
+def get_auth(get_credentials_f, oauth2_refresh_token_filename):
+    """Login into Google and return oauth2 as a dict.
 
     get_credentials_f() is called if credentials are required to log in, and
-    should return (email, password). get_pin_f() is called if a pin is required
-    to log in, and should return the pin.
+    should return oauth auth_token.
 
-    The cookies are saved/loaded from cookie_filename if possible, so
+    The oauth2 are saved/loaded from oauth2_refresh_token_filename if possible, so
     credentials may not be necessary.
 
     Raises GoogleAuthError on failure.
     """
-    cookies = _load_cookies(cookie_filename)
-    if cookies is not None:
-        return cookies
-    session = _login(get_credentials_f, get_pin_f)
-    cookies = _extract_cookies(session)
-    _save_cookies(cookie_filename, cookies)
-    return cookies
+    REFRESH_TOKEN = _load_oauth2_refresh_token(oauth2_refresh_token_filename)
+    AUTH_CODE = None
+    
+    if REFRESH_TOKEN is None:
+        AUTH_CODE = get_credentials_f()
+        
+    session = requests.Session()
+    session.cookies=requests.cookies.RequestsCookieJar()
 
+    if REFRESH_TOKEN :
+        data = { 'refresh_token':REFRESH_TOKEN, 'client_id':CLIENT_ID,'client_secret':CLIENT_SECRET,'grant_type':'refresh_token' }
+    else :
+        data = { 'code':AUTH_CODE, 'client_id':CLIENT_ID,'client_secret':CLIENT_SECRET,'grant_type':'authorization_code', 'redirect_uri':'urn:ietf:wg:oauth:2.0:oob' }
 
-def get_auth_stdin(cookie_filename):
+    r = session.post('https://accounts.google.com/o/oauth2/token', data=data)
+    js = r.json()
+    print(json.dumps(data))
+    
+    if 'refresh_token' in js:
+        REFRESH_TOKEN = js['refresh_token']
+        _save_oauth2_refresh_token(oauth2_refresh_token_filename, REFRESH_TOKEN)
+    
+    headers = { 'Authorization':'Bearer {0}'.format(js['access_token']) }
+    r = session.get('https://accounts.google.com/accounts/OAuthLogin?source=hangups&issueuberauth=1', headers=headers)
+    
+    uberauth = r.text
+    r = session.get('https://accounts.google.com/MergeSession') 
+    r = session.get('https://accounts.google.com/MergeSession?service=mail&continue=http://www.google.com&uberauth='+uberauth,
+                    headers=headers)
+   
+    oauth2 = _extract_cookies(session)
+    return oauth2
+
+def get_auth_stdin(oauth2_refresh_token_filename):
     """Wrapper for get_auth that prompts the user on stdin."""
     def get_credentials_f():
         """Prompt for and return credentials."""
-        email = input('Email: ')
-        password = getpass.getpass()
-        return (email, password)
-    def get_pin_f():
-        """Prompt for and return PIN."""
-        return input('PIN: ')
-    return get_auth(get_credentials_f, get_pin_f, cookie_filename)
+        print("Please open the following URL in browser")
+        print(OAUTH2_LOGIN_URL)
+        auth_token = input('Auth Token: ')
+        return auth_token
+        
+    return get_auth(get_credentials_f, oauth2_refresh_token_filename)
 
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    print(get_auth_stdin('cookies.json'))
+    print(get_auth_stdin('oauth2.json'))


### PR DESCRIPTION
This is my solution to #77

With OAuth2.0, user may reauthenicate with refresh_token without the fear of cookie expiration or other login page oddies. The flow was adapted from @woefulwabbit and Chromium project.

One thing is notice:
The authenication is shown as "ios device" in Google Security page. This is because the OAuth scope we use need whitelist from google. Currently, only Android, Mobile Chrome and iOS account manager's clientid have this power.  We picked iOS as the victim... 