### PR TITLE
Implemented notification level set in Client and Conversation

### DIFF
--- a/hangups/client.py
+++ b/hangups/client.py
@@ -776,6 +776,30 @@ class Client(object):
             raise exceptions.NetworkError()
 
     @asyncio.coroutine
+    def setchatnotificationlevel(self, conversation_id, level):
+        """Set the notification level of a conversation.
+        
+        Pass schemas.ClientNotificationLevel.QUIET to disable notifications,
+        or schemas.ClientNotificationLevel.RING to enable them.
+        
+        Raises hangups.NetworkError if the request fails.
+        """
+        client_generated_id = random.randint(0, 2 ** 32)
+        body = [
+            self._get_request_header(),
+            [conversation_id],
+            level.value
+        ]
+        res = yield from self._request('conversations/setconversationnotificationlevel',
+                                       body)
+        res = json.loads(res.body.decode())
+        res_status = res['response_header']['status']
+        if res_status != 'OK':
+            logger.warning('setconversationnotificationlevel returned status {}'
+                           .format(res_status))
+            raise exceptions.NetworkError()
+
+    @asyncio.coroutine
     def sendeasteregg(self, conversation_id, easteregg):
         """Send a easteregg to a conversation.
 

--- a/hangups/client.py
+++ b/hangups/client.py
@@ -776,7 +776,7 @@ class Client(object):
             raise exceptions.NetworkError()
 
     @asyncio.coroutine
-    def setchatnotificationlevel(self, conversation_id, level):
+    def setconversationnotificationlevel(self, conversation_id, level):
         """Set the notification level of a conversation.
         
         Pass schemas.ClientNotificationLevel.QUIET to disable notifications,

--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -160,7 +160,7 @@ class Conversation(object):
         yield from self._client.setchatname(self.id_, name)
 
     @asyncio.coroutine
-    def setnotificationlevel(self, level):
+    def set_notification_level(self, level):
         """Set the notification level of the conversation.
 
         Pass schemas.ClientNotificationLevel.QUIET to disable notifications,
@@ -168,7 +168,7 @@ class Conversation(object):
 
         Raises hangups.NetworkError if the request fails.
         """
-        yield from self._client.setchatnotificationlevel(self.id_, level)
+        yield from self._client.setconversationnotificationlevel(self.id_, level)
 
     @asyncio.coroutine
     def set_typing(self, typing=schemas.TypingStatus.TYPING):

--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -160,6 +160,17 @@ class Conversation(object):
         yield from self._client.setchatname(self.id_, name)
 
     @asyncio.coroutine
+    def setnotificationlevel(self, level):
+        """Rename the conversation.
+
+        Pass schemas.ClientNotificationLevel.QUIET to disable notifications,
+        or schemas.ClientNotificationLevel.RING to enable them.
+
+        Raises hangups.NetworkError if the request fails.
+        """
+        yield from self._client.setchatnotificationlevel(self.id_, level)
+
+    @asyncio.coroutine
     def set_typing(self, typing=schemas.TypingStatus.TYPING):
         """Set typing status.
 

--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -161,7 +161,7 @@ class Conversation(object):
 
     @asyncio.coroutine
     def setnotificationlevel(self, level):
-        """Rename the conversation.
+        """Set the notification level of the conversation.
 
         Pass schemas.ClientNotificationLevel.QUIET to disable notifications,
         or schemas.ClientNotificationLevel.RING to enable them.


### PR DESCRIPTION
I needed a bot to automatically enable and disable notifications for a specific conversation, so I implemented two methods to do that.

* The first one is **`Client.setchatnotificationlevel`**: I created  it by copying `Client.setchatname`, changing the request body according to the request I captured on the official web client when changing the notification checkbox. I tested it for both enabling and disabling, and it works as expected.

* The second one is **`Conversation.setnotificationlevel`**, and it just calls the other one. I did not tested it (but it has to work!), because in my bot I don't need to create any `Conversation` object.

I decided to pass the notification level using the enum `schemas.ClientNotificationLevel`, but a different option could have been, for example, a boolean `quiet`. If you prefer, I can change it and redo the pull request.