### PR TITLE
Use readlike library in ReturnableEdit widget

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'aiohttp==0.15.1',
         'appdirs==1.4.0',
         'purplex==0.2.4',
+        'readlike>=0.1',
         'requests==2.6.0',
         'ReParser>=1.4',
         # use forked urwid until there's a 1.3 release with colour bugfix


### PR DESCRIPTION
I wanted more powerful line editing capabilities in hangups, so I wrote [a small library](https://github.com/jangler/readlike). As you can see, it integrates pretty seamlessly with the existing code, and makes sure not to steal hangups-specific key bindings... though it's a shame that it can't use `C-w` and `C-u` in hangups' default configuration :)