### PR TITLE
Fills unknown fields from takeout

### DIFF
--- a/hangups/hangouts.proto
+++ b/hangups/hangouts.proto
@@ -314,7 +314,7 @@ message Event {
 
   optional EventType event_type = 23;
 
-  // unknown timestamp = 24;
+  // "event_version" timestamp = 24;
   // unknown sending messages (['7-H0Z7-BCTg80ySBsfibNV', 4, None, 1435550921815004]) = 26;
 }
 
@@ -378,9 +378,8 @@ message ConversationParticipantData {
   optional ParticipantId id = 1;
   optional string fallback_name = 2;
   optional ParticipantType participant_type = 5;
-  // TODO: one of these is invitation_status and the other is new_invitation_status
-  // unknown (2, 1) = 3;
-  // unknown (2, 3) = 6
+  // "invitation_status" (2, 1) = 3;
+  // "new_invitation_status" (2, 3) = 6;
 }
 
 // A conversation between two or more users.
@@ -391,17 +390,17 @@ message Conversation {
   optional UserConversationState self_conversation_state = 4;
   repeated UserReadState read_state = 8;
 
-  // unknown (0) = 9;
+  // "has_active_hangout" (0) = 9;
 
   optional OffTheRecordStatus otr_status = 10;
 
-  // unknown (1) = 11;
+  // "otr_toggle" (1) = 11;
 
   repeated ParticipantId current_participant = 13;
   repeated ConversationParticipantData participant_data = 14;
-
-  // unknown ([1]) = 18;
-  // unknown (0) = 19;
+  // "fork_on_external_invite" = 17
+  // "network_type" ([1]) = 18;
+  // "force_history_state" (0) = 19;
 }
 
 message EasterEgg {


### PR DESCRIPTION
Google takeout can dump all hangouts in JSON format. Update the unknown fields from the dump.