### PR TITLE
Remove the "chat init" request and InitialData

### DIFF
--- a/hangups/__init__.py
+++ b/hangups/__init__.py
@@ -4,8 +4,8 @@
 # Keep version in a separate file so setup.py can import it separately.
 from .version import __version__
 from .client import Client
-from .user import UserList, build_user_list
-from .conversation import ConversationList
+from .user import UserList
+from .conversation import ConversationList, build_user_conversation_list
 from .auth import get_auth, get_auth_stdin, GoogleAuthError
 from .exceptions import HangupsError, NetworkError
 from .conversation_event import (ChatMessageSegment, ConversationEvent,

--- a/hangups/ui/__main__.py
+++ b/hangups/ui/__main__.py
@@ -135,14 +135,10 @@ class ChatUI(object):
         self.add_conversation_tab(conv_id, switch=True)
 
     @asyncio.coroutine
-    def _on_connect(self, initial_data):
+    def _on_connect(self):
         """Handle connecting for the first time."""
-        self._user_list = yield from hangups.build_user_list(
-            self._client, initial_data
-        )
-        self._conv_list = hangups.ConversationList(
-            self._client, initial_data.conversation_states, self._user_list,
-            initial_data.sync_timestamp
+        self._user_list, self._conv_list = (
+            yield from hangups.build_user_conversation_list(self._client)
         )
         self._conv_list.on_event.add_observer(self._on_event)
         if not self._disable_notifier:


### PR DESCRIPTION
Remove the "chat init" request used to load data on startup. It no
longer provides anything that we can't request separately without
the convoluted regex-based parsing that it requires. This also means
that InitialData is no longer required.

TODO:
* [x] fix `setactiveclient`
* [x] pick better values for `version_timestamp` and `header_id` (or just don't send them?)