### PR TITLE
Date on new line

### DIFF
--- a/hangups/ui/__main__.py
+++ b/hangups/ui/__main__.py
@@ -15,8 +15,8 @@ from hangups.ui.utils import get_conv_name
 
 
 LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-MESSAGE_TIME_FORMAT = '%I:%M:%S %p'
-MESSAGE_DATETIME_FORMAT = '%y-%m-%d %I:%M:%S %p'
+MESSAGE_TIME_FORMAT = '(%I:%M:%S %p)'
+MESSAGE_DATETIME_FORMAT = '%y-%m-%d\n(%I:%M:%S %p)'
 COL_SCHEMES = {
     # Very basic scheme with no colour
     'default': {
@@ -407,8 +407,8 @@ class MessageWidget(urwid.WidgetWrap):
         # Save the timestamp as an attribute for sorting.
         self.timestamp = timestamp
         text = [
-            ('msg_date', '(' + self._get_date_str(timestamp,
-                                                  show_date=show_date) + ') '),
+            ('msg_date', self._get_date_str(timestamp,
+                                                  show_date=show_date) + ' '),
             ('msg_text', text)
         ]
         if user is not None:

--- a/hangups/ui/__main__.py
+++ b/hangups/ui/__main__.py
@@ -16,7 +16,7 @@ from hangups.ui.utils import get_conv_name
 
 LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 MESSAGE_TIME_FORMAT = '(%I:%M:%S %p)'
-MESSAGE_DATETIME_FORMAT = '%y-%m-%d\n(%I:%M:%S %p)'
+MESSAGE_DATETIME_FORMAT = '\n< %y-%m-%d >\n(%I:%M:%S %p)'
 COL_SCHEMES = {
     # Very basic scheme with no colour
     'default': {


### PR DESCRIPTION
I'm not sure if this needs to be behind an option or not, but for usability reasons having the date on a new line makes the chat log a lot more readable.

This is what it looks like currently: 
![example](https://cloud.githubusercontent.com/assets/8798637/9822388/29b2e962-588e-11e5-93f9-a1e774c5719e.png)

One other option would be allowing users to set their own Time/Time+Date format string via the config file/command line arguments, which would admittedly be better, but I wasn't comfortable enough with the formatting of the project to make changes to config settings/command line arguments.