### PR TITLE
Use protobuf argument for Client request methods

### DIFF
--- a/hangups/__init__.py
+++ b/hangups/__init__.py
@@ -11,8 +11,9 @@ from .exceptions import HangupsError, NetworkError
 from .conversation_event import (ChatMessageSegment, ConversationEvent,
                                  ChatMessageEvent, RenameEvent,
                                  MembershipChangeEvent)
-# Only import enum values and messages from the proto file that are necessary
-# for third-party code to use hangups.
+# Only import Protocol Buffer objects that are needed for the high-level
+# hangups API (ConversationList, etc.) here. Low-level Client users could need
+# just about anything, and importing it here would create conflicts.
 from .hangouts_pb2 import (
     TYPING_TYPE_STARTED, TYPING_TYPE_PAUSED, TYPING_TYPE_STOPPED,
     MEMBERSHIP_CHANGE_TYPE_LEAVE, MEMBERSHIP_CHANGE_TYPE_JOIN

--- a/hangups/conversation_event.py
+++ b/hangups/conversation_event.py
@@ -6,7 +6,7 @@ through property methods, which prefer logging warnings to raising exceptions.
 
 import logging
 
-from hangups import parsers, message_parser, user, hangouts_pb2, pblite
+from hangups import parsers, message_parser, user, hangouts_pb2
 
 logger = logging.getLogger(__name__)
 chat_message_parser = message_parser.ChatMessageParser()
@@ -91,7 +91,7 @@ class ChatMessageSegment(object):
         )
 
     def serialize(self):
-        """Serialize the segment to pblite."""
+        """Serialize the segment to protobuf."""
         segment = hangouts_pb2.Segment(
             type=self.type_,
             text=self.text,
@@ -104,7 +104,7 @@ class ChatMessageSegment(object):
         )
         if self.link_target is not None:
             segment.link_data.link_target = self.link_target
-        return pblite.encode(segment)
+        return segment
 
 
 class ChatMessageEvent(ConversationEvent):


### PR DESCRIPTION
Change the argument for Client API request methods to be the
corresponding protobuf request message. This adds some boilerplate when
calling this methods, but allows complete flexibility in setting the
request parameters.

Also rename these methods to use snake_case instead of matching the name
of the API in the URL.

Closes #140.