### PR TITLE
Use SSL for image uploads

### DIFF
--- a/hangups/client.py
+++ b/hangups/client.py
@@ -13,7 +13,7 @@ from hangups import (javascript, exceptions, http_utils, channel, event,
 
 logger = logging.getLogger(__name__)
 ORIGIN_URL = 'https://talkgadget.google.com'
-IMAGE_UPLOAD_URL = 'http://docs.google.com/upload/photos/resumable'
+IMAGE_UPLOAD_URL = 'https://docs.google.com/upload/photos/resumable'
 # Timeout to send for setactiveclient requests:
 ACTIVE_TIMEOUT_SECS = 120
 # Minimum timeout between subsequent setactiveclient requests:


### PR DESCRIPTION
As of a few hours ago Google are rejecting non-ssl image uploads. Use ssl for IMAGE_UPLOAD_URL