### PR TITLE
provide fallback names for Google Voice SMS conversations

### DIFF
--- a/hangups/user.py
+++ b/hangups/user.py
@@ -22,8 +22,8 @@ class User(object):
                  is_self):
         """Initialize a User."""
         self.id_ = user_id
-        self.full_name = full_name if full_name != '' else DEFAULT_NAME
-        self.first_name = (first_name if first_name != ''
+        self.full_name = full_name if full_name else DEFAULT_NAME
+        self.first_name = (first_name if first_name
                            else self.full_name.split()[0])
         self.photo_url = photo_url
         self.emails = emails

--- a/hangups/user.py
+++ b/hangups/user.py
@@ -2,12 +2,14 @@
 
 from collections import namedtuple
 import logging
+from enum import IntEnum
 
 
 logger = logging.getLogger(__name__)
 DEFAULT_NAME = 'Unknown'
 
 UserID = namedtuple('UserID', ['chat_id', 'gaia_id'])
+NameType = IntEnum('NameType', dict(DEFAULT=0, NUMERIC=1, REAL=2))
 
 
 class User(object):
@@ -21,13 +23,33 @@ class User(object):
     def __init__(self, user_id, full_name, first_name, photo_url, emails,
                  is_self):
         """Initialize a User."""
+
+        if not full_name:
+            self.full_name = self.first_name = DEFAULT_NAME
+            self.name_type = NameType.DEFAULT
+        elif not any(c.isalpha() for c in full_name):
+            self.full_name = self.first_name = full_name
+            self.name_type = NameType.NUMERIC
+        else:
+            self.full_name = full_name if full_name else DEFAULT_NAME
+            self.first_name = (first_name if first_name
+                               else self.full_name.split()[0])
+            self.name_type = NameType.REAL
+
         self.id_ = user_id
-        self.full_name = full_name if full_name else DEFAULT_NAME
-        self.first_name = (first_name if first_name
-                           else self.full_name.split()[0])
         self.photo_url = photo_url
         self.emails = emails
         self.is_self = is_self
+
+    def upgrade_name(self, user_):
+        # Google Voice participants often first appear with no name at all, and then
+        # get upgraded unpredictably to numbers ("+12125551212") or names.
+        if user_.name_type > self.name_type:
+            self.full_name = user_.full_name
+            self.first_name = user_.first_name
+            self.name_type = user_.name_type
+            logging.debug('Added {} name to User "{}": {}'.format(
+                self.name_type.name.lower(), self.full_name, self))
 
     @staticmethod
     def from_entity(entity, self_user_id):
@@ -100,12 +122,19 @@ class UserList(object):
         return self._user_dict.values()
 
     def add_user_from_conv_part(self, conv_part):
-        """Add new User from ConversationParticipantData"""
+        """Add new User from ConversationParticipantData, and update their
+        name if it was previously unknown or numeric"""
         user_ = User.from_conv_part_data(conv_part, self._self_user.id_)
-        if user_.id_ not in self._user_dict:
-            logging.warning('Adding fallback User: {}'.format(user_))
+
+        existing = self._user_dict.get(user_.id_)
+        if existing is None:
+            logging.warning('Adding fallback User with {} name "{}": {}'.format(
+                user_.name_type.name.lower(), user_.full_name, user_))
             self._user_dict[user_.id_] = user_
-        return user_
+            return user_
+        else:
+            existing.upgrade_name(user_)
+            return existing
 
     def _on_state_update(self, state_update):
         """Receive a StateUpdate"""


### PR DESCRIPTION
Google Voice participants, when first loaded by `GetEntityByIdRequest`, appear on the scene with no `fallback_name`. However, subsequent `ConversationParticipantData` messages concerning these users *do* contain a useful `fallback_name`. (I mentioned this in a [comment](https://github.com/tdryer/hangups/issues/53#issuecomment-168340581) on #53.)

The nameless Google Voice participants get "upgraded," a bit unpredictably, to numbers (e.g. `+18005551212`) or real names, when subsequent `ConversationParticipantData` messages are sent by the server. This patch reacts to more-complete names as they are seen by modifying the `UserList`:
* If an existing `User` has only a default name, it will get upgraded when either a number or a name appears for the corresponding ID.
* If an existing `User` has only a number, it will get upgraded when an alphabetical name appears for that ID.

Without this change, my conversation list is all "Unknown". With this change, it becomes a mixture of names and cell-phone numbers.

I'm not really sure why this happens. My guess is that the server doesn't really cache a thorough mapping of gaia IDs to the logged-in user's contacts, when the gaia ID only maps to a phone number.

The official Android and Chrome clients appear to share this annoying lack of name resolution, though it is much rarer. I am guessing that they normally use the Google Contacts API to fill in the blanks, but occasionally some participants are shown as numbers only, even when those users' names and numbers are in my Google Contacts and have been for a long time.