### PR TITLE
fix for #121 (multiple identical first names)

### DIFF
--- a/hangups/ui/__main__.py
+++ b/hangups/ui/__main__.py
@@ -421,7 +421,7 @@ class StatusLineWidget(urwid.WidgetWrap):
 
     def _update(self):
         """Update status text."""
-        typers = [self._conversation.get_user(user_id).first_name
+        typers = [self._conversation.get_user(user_id).unique_name
                   for user_id, status in self._typing_statuses.items()
                   if status == hangups.TYPING_TYPE_STARTED]
         if len(typers) > 0:
@@ -455,7 +455,7 @@ class MessageWidget(urwid.WidgetWrap):
         ]
         if user is not None:
             text.insert(1, ('msg_self' if user.is_self else 'msg_sender',
-                            user.first_name + ': '))
+                            user.unique_name + ': '))
         self._widget = urwid.Text(text)
         super().__init__(self._widget)
 
@@ -493,10 +493,10 @@ class MessageWidget(urwid.WidgetWrap):
         elif isinstance(conv_event, hangups.RenameEvent):
             if conv_event.new_name == '':
                 text = ('{} cleared the conversation name'
-                        .format(user.first_name))
+                        .format(user.unique_name))
             else:
                 text = ('{} renamed the conversation to {}'
-                        .format(user.first_name, conv_event.new_name))
+                        .format(user.unique_name, conv_event.new_name))
             return MessageWidget(conv_event.timestamp, text, datetimefmt,
                                  show_date=is_new_day)
         elif isinstance(conv_event, hangups.MembershipChangeEvent):
@@ -505,7 +505,7 @@ class MessageWidget(urwid.WidgetWrap):
             names = ', '.join([user.full_name for user in event_users])
             if conv_event.type_ == hangups.MEMBERSHIP_CHANGE_TYPE_JOIN:
                 text = ('{} added {} to the conversation'
-                        .format(user.first_name, names))
+                        .format(user.unique_name, names))
             else:  # LEAVE
                 text = ('{} left the conversation'.format(names))
             return MessageWidget(conv_event.timestamp, text, datetimefmt,

--- a/hangups/ui/utils.py
+++ b/hangups/ui/utils.py
@@ -30,7 +30,7 @@ def get_conv_name(conv, truncate=False, show_unread=False):
             (user for user in conv.users if not user.is_self),
             key=lambda user: user.id_
         )
-        names = [user.first_name for user in participants]
+        names = [user.unique_name for user in participants]
         if len(participants) == 0:
             return "Empty Conversation" + postfix
         if len(participants) == 1:

--- a/hangups/user.py
+++ b/hangups/user.py
@@ -22,8 +22,8 @@ class User(object):
                  is_self):
         """Initialize a User."""
         self.id_ = user_id
-        self.full_name = full_name if full_name != '' else DEFAULT_NAME
-        self.first_name = (first_name if first_name != ''
+        self.full_name = full_name if full_name else DEFAULT_NAME
+        self.first_name = (first_name if first_name
                            else self.full_name.split()[0])
         self.photo_url = photo_url
         self.emails = emails

--- a/hangups/user.py
+++ b/hangups/user.py
@@ -2,12 +2,14 @@
 
 from collections import namedtuple
 import logging
+from enum import IntEnum
 
 
 logger = logging.getLogger(__name__)
 DEFAULT_NAME = 'Unknown'
 
 UserID = namedtuple('UserID', ['chat_id', 'gaia_id'])
+NameType = IntEnum('NameType', dict(DEFAULT=0, NUMERIC=1, REAL=2))
 
 
 class User(object):
@@ -21,13 +23,33 @@ class User(object):
     def __init__(self, user_id, full_name, first_name, photo_url, emails,
                  is_self):
         """Initialize a User."""
+
+        if not full_name:
+            self.full_name = self.first_name = DEFAULT_NAME
+            self.name_type = NameType.DEFAULT
+        elif not any(c.isalpha() for c in full_name):
+            self.full_name = self.first_name = full_name
+            self.name_type = NameType.NUMERIC
+        else:
+            self.full_name = full_name if full_name else DEFAULT_NAME
+            self.first_name = (first_name if first_name
+                               else self.full_name.split()[0])
+            self.name_type = NameType.REAL
+
         self.id_ = user_id
-        self.full_name = full_name if full_name else DEFAULT_NAME
-        self.first_name = (first_name if first_name
-                           else self.full_name.split()[0])
         self.photo_url = photo_url
         self.emails = emails
         self.is_self = is_self
+
+    def upgrade_name(self, user_):
+        # Google Voice participants often first appear with no name at all, and then
+        # get upgraded unpredictably to numbers ("+12125551212") or names.
+        if user_.name_type > self.name_type:
+            self.full_name = user_.full_name
+            self.first_name = user_.first_name
+            self.name_type = user_.name_type
+            logging.debug('Added {} name to User "{}": {}'.format(
+                self.name_type.name.lower(), self.full_name, self))
 
     @staticmethod
     def from_entity(entity, self_user_id):
@@ -100,12 +122,19 @@ class UserList(object):
         return self._user_dict.values()
 
     def add_user_from_conv_part(self, conv_part):
-        """Add new User from ConversationParticipantData"""
+        """Add new User from ConversationParticipantData, and update their
+        name if it was previously unknown or numeric"""
         user_ = User.from_conv_part_data(conv_part, self._self_user.id_)
-        if user_.id_ not in self._user_dict:
-            logging.warning('Adding fallback User: {}'.format(user_))
+
+        existing = self._user_dict.get(user_.id_)
+        if existing is None:
+            logging.warning('Adding fallback User with {} name "{}": {}'.format(
+                user_.name_type.name.lower(), user_.full_name, user_))
             self._user_dict[user_.id_] = user_
-        return user_
+            return user_
+        else:
+            existing.upgrade_name(user_)
+            return existing
 
     def _on_state_update(self, state_update):
         """Receive a StateUpdate"""


### PR DESCRIPTION
This builds on top of #200, and fixes the issue of identical first names leading to a hard-to-follow conversations.

As a Daniel with many friends named Dan or Daniel, I feel the pain of the folks who reported #121 :+1:.

Any time a new user appears in the user list, this patch revisits the `UserList` and ensures that each name is represented uniquely by including (only if necessary) either the last initial or the whole name.

For example, this userlist would be mapped as follows:

```
Daniel Smith   -> Daniel S
Daniel Jones   -> Daniel Jones
Daniel Johnson -> Daniel Johnson
Daniel Lenski  -> Daniel L
Steve Jones    -> Steve
```

Now, if a new user ("Daniel Schmidt") joins the party, both Daniel Smith and Daniel Schmidt's _full_ last names will be added.
