### PR TITLE
Document support for readline bindings in user guide

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -50,7 +50,11 @@ tab. Once multiple tabs are open, use :code:`ctrl+u` and :code:`ctrl+d` and
 move up and down the list of tabs. Use :code:`ctrl+w` to close a tab.
 
 In a conversation tab, type a message and press :code:`enter` to send it, or
-use the up and arrows to scroll the list of previous messages.
+use the up and arrows to scroll the list of previous messages. hangups
+supports readline commands for editing text. See the `readlike library
+documentation`_ for a full list. Note that some of hangouts' bindings
+conflict with these key combinations, see the Configuration section on how to
+adjust key bindings.
 
 When new messages arrive, hangups will open a conversation tab in the
 background, and display the number of unread messages in the tab title. On
@@ -65,6 +69,8 @@ missed during the disconnection. If hangups is disconnected for too long, it
 will eventually exit.
 
 To exit hangups, press :code:`ctrl+e`.
+
+.. _readlike library documentation: https://pypi.python.org/pypi/readlike
 
 Configuration
 -------------


### PR DESCRIPTION
None of the documentation mentions that readline key bindings are available. This adds a short blurb about it with a link to a comprehensive list of available commands.

Funny story: I had hacked hangups a long time ago to support `ctrl a` and `ctrl e` (beginning-of-line and end-of-line, respectively) through `urwid.Edit._command_map`. All the while I didn't realize that this was provided by @jangler's readlike. They were just clobbered by the default bindings (`ctrl e` anyway). I began to prepare a formal patch and finally noticed readlike being used. Whoops.

Anyway, in #131 you mentioned the possibility of reconsidering the default key bindings. I'd like to offer my key config in hopes to help persuade you. :)

```
key-prev-tab: ctrl p
key-next-tab: ctrl n
key-close-tab: ctrl x
key-quit: meta x
key-menu: ctrl m
```

None of these conflict with the more useful readline key bindings[1]. If you still aren't ready to change the defaults, then I would propose, as part of this PR, that I add some additional documentation to the Configuration section with a note about readline and this key config.

[1] `ctrl p` and `ctrl n` *are* quite useful for command history but I don't think they are useful for hangups unless it gains a command line.