### PR TITLE
Add Sphinx autodoc pages for developer guide

### DIFF
--- a/docs/developer_guide/auth.rst
+++ b/docs/developer_guide/auth.rst
@@ -1,0 +1,5 @@
+Auth
+====
+
+.. automodule:: hangups.auth
+    :members:

--- a/docs/developer_guide/client.rst
+++ b/docs/developer_guide/client.rst
@@ -1,0 +1,5 @@
+Client
+======
+
+.. automodule:: hangups.client
+    :members:

--- a/docs/developer_guide/conversation.rst
+++ b/docs/developer_guide/conversation.rst
@@ -1,0 +1,5 @@
+Conversation
+============
+
+.. automodule:: hangups.conversation
+    :members:

--- a/docs/developer_guide/conversation_event.rst
+++ b/docs/developer_guide/conversation_event.rst
@@ -1,0 +1,5 @@
+Conversation Event
+==================
+
+.. automodule:: hangups.conversation_event
+    :members:

--- a/docs/developer_guide/event.rst
+++ b/docs/developer_guide/event.rst
@@ -1,0 +1,5 @@
+Event
+=====
+
+.. automodule:: hangups.event
+    :members:

--- a/docs/developer_guide/exceptions.rst
+++ b/docs/developer_guide/exceptions.rst
@@ -1,0 +1,5 @@
+Exceptions
+==========
+
+.. automodule:: hangups.exceptions
+    :members:

--- a/docs/developer_guide/index.rst
+++ b/docs/developer_guide/index.rst
@@ -1,12 +1,21 @@
 Developer Guide
 ===============
 
-This page is intended for developers who want to use the hangups library to
+This section is intended for developers who want to use the hangups library to
 write their own applications.
-
-Example
--------
 
 See the `examples directory`_ for examples of using hangups as a library.
 
 .. _examples directory: https://github.com/tdryer/hangups/tree/master/examples
+
+.. toctree::
+   :maxdepth: 2
+
+   auth
+   client
+   conversation_event
+   conversation
+   event
+   exceptions
+   message_parser
+   user

--- a/docs/developer_guide/message_parser.rst
+++ b/docs/developer_guide/message_parser.rst
@@ -1,0 +1,5 @@
+Message Parser
+==============
+
+.. automodule:: hangups.message_parser
+    :members:

--- a/docs/developer_guide/user.rst
+++ b/docs/developer_guide/user.rst
@@ -1,0 +1,5 @@
+User
+====
+
+.. automodule:: hangups.user
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ Documentation Contents
 
    installation
    user_guide
-   developer_guide
+   developer_guide/index
    protocol
 
 Indices and tables

--- a/hangups/client.py
+++ b/hangups/client.py
@@ -531,6 +531,7 @@ class Client(object):
 
     @asyncio.coroutine
     def modify_otr_status(self, modify_otr_status_request):
+        """Enable or disable message history in a conversation."""
         response = hangouts_pb2.ModifyOTRStatusResponse()
         yield from self._pb_request('conversations/modifyotrstatus',
                                     modify_otr_status_request, response)

--- a/hangups/conversation_event.py
+++ b/hangups/conversation_event.py
@@ -173,7 +173,7 @@ class OTREvent(ConversationEvent):
 
     @property
     def new_otr_status(self):
-        """The conversation's old OTR status."""
+        """The conversation's new OTR status."""
         return self._event.otr_modification.new_otr_status
 
     @property


### PR DESCRIPTION
Having spent a lot of time scanning through the code to find the methods I need, I thought it might be useful to just add the API docs into Sphinx.

This uses the same file layout as the library's structure -- a new file would need a corresponding doc page, but methods to document are auto-generated.  (The alternative is to autodoc the whole module, but that would produce one very long page.)

I have excluded what appear to be the more internal classes, but it's easy enough to add them in.