### PR TITLE
Obtain the initial conversation list more robustly

### DIFF
--- a/examples/build_conversation_list.py
+++ b/examples/build_conversation_list.py
@@ -16,16 +16,30 @@ def sync_recent_conversations(client, _):
     all_conversations = conversation_list.get_all(include_archived=True)
 
     print('{} known users'.format(len(all_users)))
-    for user in all_users:
-        print('    {}: {}'.format(user.full_name, user.id_.gaia_id))
+    for idx, user in enumerate(all_users):
+        name = user.full_name
+        gaia_id = user.id_.gaia_id
+        print('    ({}) {}: {}'.format(idx + 1, name, gaia_id))
 
     print('{} known conversations'.format(len(all_conversations)))
-    for conversation in all_conversations:
+    for idx, conversation in enumerate(all_conversations):
+        cid = conversation.id_
+
         if conversation.name:
-            name = conversation.name
+            # This conversation is named
+            name = '{} ({})'.format(conversation.name, cid)
         else:
-            name = 'Unnamed conversation ({})'.format(conversation.id_)
-        print('    {}'.format(name))
+            # This conversation isn't named; just generate a name from
+            # the full names of users in the conversation that aren't us.
+            users = ', '.join(
+                map(lambda u: u.full_name,
+                    filter(lambda u: u.id_ != user_list._self_user.id_,
+                           conversation.users)
+                )
+            )
+            name = 'Conversation with {} ({})'.format(users, cid)
+
+        print('    ({}) {}'.format(idx + 1, name))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As it turns out, Hangouts can create conversations without a single
event (including invites to the conversation itself). Also as it turns
out, there are three separate locations where a timestamp is obtainable
in the ConversationState proto:

- `conversation.self_conversation_state.sort_timestamp`
- `event_continuation_token.event_timestamp`
- `event[0].timestamp`

Switch from using `event[0].timestamp` to
`conversation.self_conversation_state.sort_timestamp` to retrieve
pages of conversations:

- SyncRecentConversations appears to monotonically order returned
  conversations by their `sort_timestamp`, NOT their event timestamps
- Hangups uses the sort timestamp for the `last_modified` conversation
  attribute, which gets called from the UI

Upon testing, this appeared to return a maximally large set of hangouts,
so it's a more correct method than the existing use of the event
timestamps anyway.

Also, update `examples/build_conversation_list.py`, as the updated code
was useful in tracking down a potential solution to #297.