### PR TITLE
Add PyInstaller build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cookies.txt
 .idea/
 .cache/
 htmlcov/
+pyinstaller/hangups.spec

--- a/pyinstaller/Dockerfile
+++ b/pyinstaller/Dockerfile
@@ -1,0 +1,19 @@
+# CentOS 6 (for glibc forward-compatibility) with Python 3.5 and PyInstaller
+
+FROM centos:6
+MAINTAINER Tom Dryer <tomdryer.com@gmail.com>
+
+RUN yum install -y curl gcc make openssl-devel
+
+RUN curl -LO https://www.python.org/ftp/python/3.5.3/Python-3.5.3.tgz && \
+    tar -xzf Python-3.5.3.tgz && \
+    cd Python-3.5.3 && \
+    ./configure --enable-shared --enable-ipv6 --enable-optimizations && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf Python-3.5.3 Python-3.5.3.tgz
+
+ENV LD_LIBRARY_PATH /usr/local/lib
+
+RUN /usr/local/bin/pip3 install pyinstaller

--- a/pyinstaller/Makefile
+++ b/pyinstaller/Makefile
@@ -1,0 +1,36 @@
+SCRIPT_PATH=wrapper.py
+DIST_PATH=dist
+WORK_PATH=build
+APP_NAME=hangups
+VERSION=$(shell grep -E --only-matching "[0-9.]+" ../hangups/version.py)
+DIST_NAME=${APP_NAME}-${VERSION}-linux-x86_64
+SUDO_USER?=${USER}
+
+DOCKER_VOLUME=/opt/build
+DOCKER_TAG=pyinstaller
+
+pyinstaller:
+	pyinstaller \
+		--hidden-import=pkg_resources \
+		--clean \
+		--strip \
+		--noconfirm \
+		--workpath "${WORK_PATH}" \
+		--distpath "${DIST_PATH}" \
+		--name "${APP_NAME}" \
+		"${SCRIPT_PATH}"
+	"${DIST_PATH}/${APP_NAME}/${APP_NAME}" --version
+	rm -rf "${DIST_PATH}/${DIST_NAME}"
+	mv "${DIST_PATH}/${APP_NAME}" "${DIST_PATH}/${DIST_NAME}"
+	tar -zcvf "${DIST_PATH}/${DIST_NAME}.tar.gz" --directory "${DIST_PATH}" "${DIST_NAME}"
+
+docker-pyinstaller:
+	docker build -t "${DOCKER_TAG}" .
+	docker run --rm --volume "${realpath ..}:${DOCKER_VOLUME}" --workdir "${DOCKER_VOLUME}" \
+		"${DOCKER_TAG}" bash -c "pip3 install . && make --directory pyinstaller"
+	chown --recursive "${SUDO_USER}:${SUDO_USER}" "${DIST_PATH}"
+
+clean:
+	rm -rf "${WORK_PATH}" "${APP_NAME}.spec" "${DIST_PATH}/${DIST_NAME}" "${DIST_PATH}/${APP_NAME}"
+
+.PHONY: pyinstaller docker-pyinstaller clean

--- a/pyinstaller/wrapper.py
+++ b/pyinstaller/wrapper.py
@@ -1,0 +1,30 @@
+"""Wrapper script to fix aiohttp certificate validation.
+
+PyInstaller bundles OpenSSL with hangups. The path that OpenSSL searches for CA
+certificates is set at compile time, so to make hangups portable between Linux
+distributions we need to use the SSL_CERT_FILE or SSL_CERT_PATH environment
+variables to override it.
+
+Set SSL_CERT_FILE to the CA certificates bundled by requests. This allows
+aiohttp to validate certificates.
+"""
+
+import os
+import sys
+
+import hangups.ui.__main__
+
+
+def main():
+    cert_file = os.path.join(sys._MEIPASS, 'requests', 'cacert.pem')
+    actual_cert_file = os.environ.setdefault('SSL_CERT_FILE', cert_file)
+    try:
+        open(actual_cert_file)
+    except FileNotFoundError as e:
+        sys.exit('Failed to find CA certificates: {}'.format(e))
+
+    hangups.ui.__main__.main()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add build scripts for producing a [PyInstaller](http://www.pyinstaller.org/) distribution of hangups for Linux x86_64.

The result is an archive containing hangups that should work on any Linux distribution with glibc >= 2.12 (CentOS 6+, Ubuntu 12.04+, or similar). No Python required!

Sample: http://tomdryer.com/hangups/hangups-0.4.2-linux-x86_64.tar.gz

```
tar xf hangups-0.4.2-linux-x86_64.tar.gz
hangups-0.4.2-linux-x86_64/hangups
```