### PR TITLE
Use latest version of aiohttp as of today.

### DIFF
--- a/hangups/channel.py
+++ b/hangups/channel.py
@@ -308,11 +308,11 @@ class Channel(object):
             ), CONNECT_TIMEOUT)
         except asyncio.TimeoutError:
             raise exceptions.NetworkError('Request timed out')
-        except aiohttp.ClientError as e:
-            raise exceptions.NetworkError('Request connection error: {}'
-                                          .format(e))
         except aiohttp.ServerDisconnectedError as e:
             raise exceptions.NetworkError('Server disconnected error: {}'
+                                          .format(e))
+        except aiohttp.ClientError as e:
+            raise exceptions.NetworkError('Request connection error: {}'
                                           .format(e))
         if res.status == 400 and res.reason == 'Unknown SID':
             raise UnknownSIDError('SID became invalid')
@@ -328,11 +328,11 @@ class Channel(object):
                 )
             except asyncio.TimeoutError:
                 raise exceptions.NetworkError('Request timed out')
-            except aiohttp.ClientError as e:
-                raise exceptions.NetworkError('Request connection error: {}'
-                                              .format(e))
             except aiohttp.ServerDisconnectedError as e:
                 raise exceptions.NetworkError('Server disconnected error: {}'
+                                              .format(e))
+            except aiohttp.ClientError as e:
+                raise exceptions.NetworkError('Request connection error: {}'
                                               .format(e))
             except asyncio.CancelledError:
                 # Prevent ResourceWarning when channel is disconnected.

--- a/hangups/http_utils.py
+++ b/hangups/http_utils.py
@@ -39,10 +39,10 @@ def fetch(method, url, params=None, headers=None, cookies=None, data=None,
                          res.reason, body)
         except asyncio.TimeoutError:
             error_msg = 'Request timed out'
-        except aiohttp.ClientError as e:
-            error_msg = 'Request connection error: {}'.format(e)
         except aiohttp.ServerDisconnectedError as e:
             error_msg = 'Server disconnected error: {}'.format(e)
+        except aiohttp.ClientError as e:
+            error_msg = 'Request connection error: {}'.format(e)
         else:
             error_msg = None
             break

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ with open('README.rst') as f:
 # especially for end-users (non-developers) who use pip to install hangups.
 install_requires = [
     'ConfigArgParse==0.11.0',
-    'aiohttp>=1.2,<2',
+    'aiohttp>=2,<3',
     'appdirs>=1.4,<1.5',
     'readlike==0.1.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)


### PR DESCRIPTION
The requires line for aiohttp was previously using <2, which caused a old 2.0 release candidate version of aiohttp to be installed. The latest version of aiohttp available as of this writing is 2.0.7, which seems to work fine, so let's use that version as the upper bound rather than an old release candidate.