### PR TITLE
Cleanup Responses

### DIFF
--- a/hangups/channel.py
+++ b/hangups/channel.py
@@ -329,7 +329,7 @@ class Channel(object):
             raise exceptions.NetworkError('Request connection error: %s' % err)
         finally:
             if 'res' in locals():
-                res.close()
+                res.release()
 
     @asyncio.coroutine
     def _on_push_data(self, data_bytes):

--- a/hangups/channel.py
+++ b/hangups/channel.py
@@ -325,6 +325,11 @@ class Channel(object):
             try:
                 chunk = yield from asyncio.wait_for(
                     res.content.read(MAX_READ_BYTES), PUSH_TIMEOUT)
+                if not chunk:
+                    break
+
+                yield from self._on_push_data(chunk)
+
             except asyncio.TimeoutError:
                 raise exceptions.NetworkError('Request timed out')
             except aiohttp.ServerDisconnectedError as err:
@@ -339,10 +344,6 @@ class Channel(object):
                 if not chunk:
                     # Prevent ResourceWarning when channel is disconnected.
                     res.close()
-            if not chunk:
-                break
-
-            yield from self._on_push_data(chunk)
 
     @asyncio.coroutine
     def _on_push_data(self, data_bytes):

--- a/hangups/channel.py
+++ b/hangups/channel.py
@@ -299,6 +299,7 @@ class Channel(object):
         }
         headers = get_authorization_headers(self._cookies['SAPISID'])
         logger.info('Opening new long-polling request')
+        res = None
         try:
             res = yield from asyncio.wait_for(aiohttp.request(
                 'get', CHANNEL_URL_PREFIX.format('channel/bind'),
@@ -328,7 +329,7 @@ class Channel(object):
         except aiohttp.ClientError as err:
             raise exceptions.NetworkError('Request connection error: %s' % err)
         finally:
-            if 'res' in locals():
+            if res is not None:
                 res.release()
 
     @asyncio.coroutine

--- a/hangups/channel.py
+++ b/hangups/channel.py
@@ -303,47 +303,46 @@ class Channel(object):
             res = yield from asyncio.wait_for(aiohttp.request(
                 'get', CHANNEL_URL_PREFIX.format('channel/bind'),
                 params=params, cookies=self._cookies, headers=headers,
-                connector=self._connector
-            ), CONNECT_TIMEOUT)
+                connector=self._connector), CONNECT_TIMEOUT)
         except asyncio.TimeoutError:
             raise exceptions.NetworkError('Request timed out')
-        except aiohttp.ServerDisconnectedError as e:
-            raise exceptions.NetworkError('Server disconnected error: {}'
-                                          .format(e))
-        except aiohttp.ClientError as e:
-            raise exceptions.NetworkError('Request connection error: {}'
-                                          .format(e))
-        if res.status == 400 and res.reason == 'Unknown SID':
-            raise UnknownSIDError('SID became invalid')
-        elif res.status != 200:
+        except aiohttp.ServerDisconnectedError as err:
             raise exceptions.NetworkError(
-                'Request return unexpected status: {}: {}'
-                .format(res.status, res.reason)
-            )
+                'Server disconnected error: %s' % err)
+        except aiohttp.ClientError as err:
+            raise exceptions.NetworkError('Request connection error: %s' % err)
+        finally:
+            if 'res' in locals() and res.status != 200:
+                res.close()
+                if res.status == 400 and res.reason == 'Unknown SID':
+                    raise UnknownSIDError('SID became invalid')
+                raise exceptions.NetworkError(
+                    'Request return unexpected status: {}: {}'.format(
+                        res.status, res.reason))
+
         while True:
+            chunk = None
             try:
                 chunk = yield from asyncio.wait_for(
-                    res.content.read(MAX_READ_BYTES), PUSH_TIMEOUT
-                )
+                    res.content.read(MAX_READ_BYTES), PUSH_TIMEOUT)
             except asyncio.TimeoutError:
                 raise exceptions.NetworkError('Request timed out')
-            except aiohttp.ServerDisconnectedError as e:
+            except aiohttp.ServerDisconnectedError as err:
                 raise exceptions.NetworkError('Server disconnected error: {}'
-                                              .format(e))
-            except aiohttp.ClientError as e:
+                                              .format(err))
+            except aiohttp.ClientError as err:
                 raise exceptions.NetworkError('Request connection error: {}'
-                                              .format(e))
+                                              .format(err))
             except asyncio.CancelledError:
-                # Prevent ResourceWarning when channel is disconnected.
-                res.close()
                 raise
-            if chunk:
-                yield from self._on_push_data(chunk)
-            else:
-                # Close the response to allow the connection to be reused for
-                # the next request.
-                res.close()
+            finally:
+                if not chunk:
+                    # Prevent ResourceWarning when channel is disconnected.
+                    res.close()
+            if not chunk:
                 break
+
+            yield from self._on_push_data(chunk)
 
     @asyncio.coroutine
     def _on_push_data(self, data_bytes):

--- a/hangups/http_utils.py
+++ b/hangups/http_utils.py
@@ -46,6 +46,9 @@ def fetch(method, url, params=None, headers=None, cookies=None, data=None,
         else:
             error_msg = None
             break
+        finally:
+            if 'res' in locals():
+                res.close()
         logger.info('Request attempt %d failed: %s', retry_num, error_msg)
     if error_msg:
         logger.info('Request failed after %d attempts', MAX_RETRIES)

--- a/hangups/http_utils.py
+++ b/hangups/http_utils.py
@@ -29,6 +29,7 @@ def fetch(method, url, params=None, headers=None, cookies=None, data=None,
     logger.debug('Sending request %s %s:\n%r', method, url, data)
     error_msg = None
     for retry_num in range(MAX_RETRIES):
+        res = None
         try:
             res = yield from asyncio.wait_for(aiohttp.request(
                 method, url, params=params, headers=headers, cookies=cookies,
@@ -47,7 +48,7 @@ def fetch(method, url, params=None, headers=None, cookies=None, data=None,
             error_msg = None
             break
         finally:
-            if 'res' in locals():
+            if res is not None:
                 res.release()
         logger.info('Request attempt %d failed: %s', retry_num, error_msg)
     if error_msg:

--- a/hangups/http_utils.py
+++ b/hangups/http_utils.py
@@ -29,13 +29,15 @@ def fetch(method, url, params=None, headers=None, cookies=None, data=None,
     logger.debug('Sending request %s %s:\n%r', method, url, data)
     error_msg = None
     for retry_num in range(MAX_RETRIES):
-        res = None
         try:
             res = yield from asyncio.wait_for(aiohttp.request(
                 method, url, params=params, headers=headers, cookies=cookies,
                 data=data, connector=connector
             ), CONNECT_TIMEOUT)
-            body = yield from asyncio.wait_for(res.read(), REQUEST_TIMEOUT)
+            try:
+                body = yield from asyncio.wait_for(res.read(), REQUEST_TIMEOUT)
+            finally:
+                res.release()
             logger.debug('Received response %d %s:\n%r', res.status,
                          res.reason, body)
         except asyncio.TimeoutError:
@@ -47,9 +49,6 @@ def fetch(method, url, params=None, headers=None, cookies=None, data=None,
         else:
             error_msg = None
             break
-        finally:
-            if res is not None:
-                res.release()
         logger.info('Request attempt %d failed: %s', retry_num, error_msg)
     if error_msg:
         logger.info('Request failed after %d attempts', MAX_RETRIES)

--- a/hangups/http_utils.py
+++ b/hangups/http_utils.py
@@ -48,7 +48,7 @@ def fetch(method, url, params=None, headers=None, cookies=None, data=None,
             break
         finally:
             if 'res' in locals():
-                res.close()
+                res.release()
         logger.info('Request attempt %d failed: %s', retry_num, error_msg)
     if error_msg:
         logger.info('Request failed after %d attempts', MAX_RETRIES)


### PR DESCRIPTION
In the longpolling request are a few cases in which the session is current not closed properly.
e.x. a lost connection while reading from the response

re: https://github.com/hangoutsbot/hangoutsbot/issues/838

This PR adds explicit closing of the longpolling session as well as for requests to other endpoints.