### PR TITLE
Image upload with url

### DIFF
--- a/hangups/client.py
+++ b/hangups/client.py
@@ -266,9 +266,10 @@ class Client(object):
             response = json.loads(res.body.decode())
             if 'sessionStatus' not in response:
                 try:
-                    reason = (response['errorMessage']['additionalInfo']
-                              ['uploader_service.GoogleRupioAdditionalInfo']
-                              ['completionInfo']['message'])
+                    info = (response['errorMessage']['additionalInfo']
+                            ['uploader_service.GoogleRupioAdditionalInfo']
+                            ['completionInfo'])
+                    reason = '%s : %s' % (info['status'], info['message'])
                 except KeyError:
                     reason = 'unknown reason'
                 raise exceptions.NetworkError(

--- a/hangups/client.py
+++ b/hangups/client.py
@@ -268,7 +268,7 @@ class Client(object):
                 try:
                     info = (response['errorMessage']['additionalInfo']
                             ['uploader_service.GoogleRupioAdditionalInfo']
-                            ['completionInfo'])
+                            ['completionInfo']['customerSpecificInfo'])
                     reason = '%s : %s' % (info['status'], info['message'])
                 except KeyError:
                     reason = 'unknown reason'


### PR DESCRIPTION
The client method upload_image returns only the upload id to attach it then to a message.
In some cases one might also need a public url for the image. There is no additional request needed, as Google already provides a url for the image.

Note: the public url of a video upload points to an image and the video needs to be fetched via the album and image id.

This PR also covers failed uploads which raise a KeyError (e.x. #305) and raises a NetworkError with additional information instead.