### PR TITLE
fetch a missing conversation related to a StateUpdate

### DIFF
--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -816,53 +816,60 @@ class ConversationList(object):
 
         # Handle the notification
         notification_type = state_update.WhichOneof('state_update')
-        if notification_type not in ('typing_notification',
-                                     'watermark_notification',
-                                     'event_notification'):
-            return
-
-        conv_id = (state_update.event_notification.event.conversation_id.id
-                   if notification_type == 'event_notification' else
-                   getattr(state_update, notification_type).conversation_id.id)
-
-        conv = self._conv_dict.get(conv_id, None)
-
-        if conv is None:
-            logger.debug('conversation %s not found', conv_id)
-            try:
-                res = yield from self._client.get_conversation(
-                    hangouts_pb2.GetConversationRequest(
-                        request_header=self._client.get_request_header(),
-                        conversation_spec=hangouts_pb2.ConversationSpec(
-                            conversation_id=hangouts_pb2.ConversationId(
-                                id=conv_id)),
-                        include_event=False))
-            except exceptions.NetworkError as err:
-                logger.warning('failed to fetch unknown conversation %s: %s',
-                               conv_id, err)
-                return
-            conv = self._add_conversation(res.conversation_state.conversation)
 
         if notification_type == 'typing_notification':
             yield from self._handle_set_typing_notification(
-                state_update.typing_notification, conv)
+                state_update.typing_notification)
 
         elif notification_type == 'watermark_notification':
             yield from self._handle_watermark_notification(
-                state_update.watermark_notification, conv)
+                state_update.watermark_notification)
 
         elif notification_type == 'event_notification':
             yield from self._on_event(
-                state_update.event_notification.event, conv)
+                state_update.event_notification.event)
 
     @asyncio.coroutine
-    def _on_event(self, event_, conv):
+    def _fetch_conversation(self, conv_id):
+        """get a cached conversation or fetch a missing conversation
+
+        Args:
+            conv_id: string, conversation identifier
+
+        Returns:
+            Conversation instance or None if an error occured while fetching a
+             missing conversation
+        """
+        conv = self._conv_dict.get(conv_id, None)
+        if conv is not None:
+            return conv
+
+        logger.debug('conversation %s not found', conv_id)
+        try:
+            res = yield from self._client.get_conversation(
+                hangouts_pb2.GetConversationRequest(
+                    request_header=self._client.get_request_header(),
+                    conversation_spec=hangouts_pb2.ConversationSpec(
+                        conversation_id=hangouts_pb2.ConversationId(
+                            id=conv_id)),
+                    include_event=False))
+        except exceptions.NetworkError as err:
+            logger.warning('failed to fetch unknown conversation %s: %s',
+                           conv_id, err)
+            return
+
+        return self._add_conversation(res.conversation_state.conversation)
+
+    @asyncio.coroutine
+    def _on_event(self, event_):
         """Receive a hangouts_pb2.Event and fan out to Conversations.
 
         Args:
             event_: hangouts_pb2.Event instance
-            conv: Conversation instance
         """
+        conv = yield from self._fetch_conversation(event_.conversation_id.id)
+        if conv is None:
+            return
         self._sync_timestamp = parsers.from_timestamp(event_.timestamp)
         conv_event = conv.add_event(event_)
         # conv_event may be None if the event was a duplicate.
@@ -884,26 +891,32 @@ class ConversationList(object):
             self._add_conversation(conversation)
 
     @asyncio.coroutine
-    def _handle_set_typing_notification(self, set_typing_notification, conv):
+    def _handle_set_typing_notification(self, set_typing_notification):
         """Receive SetTypingNotification and update the conversation.
 
         Args:
             set_typing_notification: hangouts_pb2.SetTypingNotification
                 instance
-            conv: Conversation instance
         """
+        conv = yield from self._fetch_conversation(
+            set_typing_notification.conversation_id.id)
+        if conv is None:
+            return
         res = parsers.parse_typing_status_message(set_typing_notification)
         yield from self.on_typing.fire(res)
         yield from conv.on_typing.fire(res)
 
     @asyncio.coroutine
-    def _handle_watermark_notification(self, watermark_notification, conv):
+    def _handle_watermark_notification(self, watermark_notification):
         """Receive WatermarkNotification and update the conversation.
 
         Args:
             watermark_notification: hangouts_pb2.WatermarkNotification instance
-            conv: Conversation instance
         """
+        conv = yield from self._fetch_conversation(
+            watermark_notification.conversation_id.id)
+        if conv is None:
+            return
         res = parsers.parse_watermark_notification(watermark_notification)
         yield from self.on_watermark_notification.fire(res)
         yield from conv.on_watermark_notification.fire(res)
@@ -936,7 +949,7 @@ class ConversationList(object):
                         if timestamp > self._sync_timestamp:
                             # This updates the sync_timestamp for us, as well
                             # as triggering events.
-                            yield from self._on_event(event_, conv)
+                            yield from self._on_event(event_)
                 else:
                     self._add_conversation(conv_state.conversation,
                                            conv_state.event)


### PR DESCRIPTION
This PR addresses #142 

Hangups receives a StateUpdate from a conversation that is not in the internal conversation cache/list, creates an API request to fill the cache miss and continues to handle the update.

If the request fails, a warning with the reason will be logged and the StateUpdate discard.

See the attached log extract on level DEBUG for details. I stripped the content that is not important for this PR.

[hangups_fetch_missing_conversation_debug.txt](https://github.com/tdryer/hangups/files/1050538/hangups_fetch_missing_conversation_debug.txt)
