### PR TITLE
hotfix for aiohttp v2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ with open('README.rst') as f:
 # especially for end-users (non-developers) who use pip to install hangups.
 install_requires = [
     'ConfigArgParse==0.11.0',
-    'aiohttp>=1.3,<3',
+    'aiohttp>=1.3,<2.2',
     'appdirs>=1.4,<1.5',
     'readlike==0.1.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)


### PR DESCRIPTION
This PR addresses #340 until a resolution of #326 or a fix in aiohttp.

aiohttp version 2.2.0 does not close the ```aiohttp.ClientSession``` created in ```aiohttp.request```.

A side effect of this: the log will be spammed with resource warnings on level ERROR as a resource warning is raised on every request to the api endpoints using ``aiohttp==2.2.0``.