### PR TITLE
introduce a virtual environment for hangups develoment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cookies.txt
 .idea/
 .cache/
 htmlcov/
+venv

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ proto_py = hangups/hangouts_pb2.py
 proto_doc = docs/proto.rst
 test_proto = hangups/test/test_pblite.proto
 test_proto_py = hangups/test/test_pblite_pb2.py
+venv_path = venv
 
 all: $(proto_py) $(test_proto_py) $(proto_doc)
 
@@ -16,6 +17,19 @@ $(test_proto_py): $(test_proto)
 
 $(proto_doc): $(proto)
 	python docs/generate_proto_docs.py $(proto) > $(proto_doc)
+
+venv.build: .clean
+	@rm -rf $(venv_path)
+	@virtualenv $(venv_path)
+	@$(venv_path)/bin/pip install -r requirements-dev.txt
+
+test: .clean
+	@$(venv_path)/bin/pip install -e ./
+	@$(venv_path)/bin/pylint -j 4 ./hangups
+	@$(venv_path)/bin/py.test -q ./hangups/test
+
+.clean:
+	@rm -rf `find . -name __pycache__`
 
 clean:
 	rm -f $(proto_py) $(proto_doc) $(test_proto_py)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+httpretty
+pylint
+pytest-sugar
+-e .


### PR DESCRIPTION
Having a separate virutal environment allows faster tests on the current development build.

The virtual environment is located in the repository folder under ``venv``.
- ``make venv.build`` creates the venv
- ``make test`` installs the latest build, runs a pylint test and then exisiting pytests in ``hangups/test``

``make test`` will fail in the pylint part, https://github.com/tdryer/hangups/pull/343 resolves these issues.