### PR TITLE
Use aiohttp.ClientSession for all HTTP requests

### DIFF
--- a/hangups/http_utils.py
+++ b/hangups/http_utils.py
@@ -4,6 +4,7 @@ import aiohttp
 import asyncio
 import collections
 import logging
+import os
 
 from hangups import exceptions
 
@@ -17,8 +18,7 @@ FetchResponse = collections.namedtuple('FetchResponse', ['code', 'body',
 
 
 @asyncio.coroutine
-def fetch(method, url, params=None, headers=None, cookies=None, data=None,
-          connector=None):
+def fetch(session, method, url, params=None, headers=None, data=None):
     """Make an HTTP request.
 
     If the request times out or a encounters a connection issue, it will be
@@ -30,9 +30,9 @@ def fetch(method, url, params=None, headers=None, cookies=None, data=None,
     error_msg = None
     for retry_num in range(MAX_RETRIES):
         try:
-            res = yield from asyncio.wait_for(aiohttp.request(
-                method, url, params=params, headers=headers, cookies=cookies,
-                data=data, connector=connector
+            res = yield from asyncio.wait_for(session.request(
+                method, url, params=params, headers=headers, data=data,
+                proxy=os.environ.get('HTTP_PROXY')
             ), CONNECT_TIMEOUT)
             try:
                 body = yield from asyncio.wait_for(res.read(), REQUEST_TIMEOUT)

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ with open('README.rst') as f:
 # especially for end-users (non-developers) who use pip to install hangups.
 install_requires = [
     'ConfigArgParse==0.11.0',
-    'aiohttp>=1.3,<2.2',
+    'aiohttp>=1.3',
     'appdirs>=1.4,<1.5',
     'readlike==0.1.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ with open('README.rst') as f:
 # especially for end-users (non-developers) who use pip to install hangups.
 install_requires = [
     'ConfigArgParse==0.11.0',
-    'aiohttp>=1.3',
+    'aiohttp>=1.3,<3',
     'appdirs>=1.4,<1.5',
     'readlike==0.1.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)


### PR DESCRIPTION
Use `aiohttp.ClientSession` for all HTTP requests instead of the older `aiohttp.request` interface.

This allows us to upgrade to aiohttp 2.2 (see #341). 

This should also fix `HTTP_PROXY` support for aiohttp >= 2.

Areas for future refactoring:
* `Client` now has many attributes which are `None` until `connect` is called.
* Cookies are now present in both `Client._cookies` and the `ClientSession`.
* Proxy support is implemented in two places.
