### PR TITLE
Bugfix for a new conversation opened with hangups

### DIFF
--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -561,7 +561,8 @@ class Conversation(object):
             NetworkError: If the timestamp cannot be updated.
         """
         if read_timestamp is None:
-            read_timestamp = self.events[-1].timestamp
+            read_timestamp = (self.events[-1].timestamp if self.events
+                              else datetime.datetime.utcnow())
         if read_timestamp > self.latest_read_timestamp:
             logger.info(
                 'Setting {} latest_read_timestamp from {} to {}'

--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -561,8 +561,8 @@ class Conversation(object):
             NetworkError: If the timestamp cannot be updated.
         """
         if read_timestamp is None:
-            read_timestamp = (self.events[-1].timestamp if self.events
-                              else datetime.datetime.utcnow())
+            read_timestamp = (self.events[-1].timestamp if self.events else
+                              datetime.datetime.now(datetime.timezone.utc))
         if read_timestamp > self.latest_read_timestamp:
             logger.info(
                 'Setting {} latest_read_timestamp from {} to {}'


### PR DESCRIPTION
Add the current utc time as a second fallback for the read timestamp, as in case of a new conversation there are no events present to get a timestamp from.

A traceback can be found in #356.