### PR TITLE
Fix NameError for typing and watermark events

### DIFF
--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -927,6 +927,8 @@ class ConversationList(object):
                 instance
         """
         conv_id = set_typing_notification.conversation_id.id
+        res = parsers.parse_typing_status_message(set_typing_notification)
+        yield from self.on_typing.fire(res)
         try:
             conv = yield from self._get_or_fetch_conversation(conv_id)
         except exceptions.NetworkError:
@@ -934,9 +936,8 @@ class ConversationList(object):
                 'Failed to fetch conversation for typing notification: %s',
                 conv_id
             )
-        res = parsers.parse_typing_status_message(set_typing_notification)
-        yield from self.on_typing.fire(res)
-        yield from conv.on_typing.fire(res)
+        else:
+            yield from conv.on_typing.fire(res)
 
     @asyncio.coroutine
     def _handle_watermark_notification(self, watermark_notification):
@@ -946,6 +947,8 @@ class ConversationList(object):
             watermark_notification: hangouts_pb2.WatermarkNotification instance
         """
         conv_id = watermark_notification.conversation_id.id
+        res = parsers.parse_watermark_notification(watermark_notification)
+        yield from self.on_watermark_notification.fire(res)
         try:
             conv = yield from self._get_or_fetch_conversation(conv_id)
         except exceptions.NetworkError:
@@ -953,9 +956,8 @@ class ConversationList(object):
                 'Failed to fetch conversation for watermark notification: %s',
                 conv_id
             )
-        res = parsers.parse_watermark_notification(watermark_notification)
-        yield from self.on_watermark_notification.fire(res)
-        yield from conv.on_watermark_notification.fire(res)
+        else:
+            yield from conv.on_watermark_notification.fire(res)
 
     @asyncio.coroutine
     def _sync(self):


### PR DESCRIPTION
Receiving a typing/watermark event for a conversation that is not present in our conversation-list can cause a `NameError` for `conv` in case of failed conversation fetch request.

We can fix this by handling typing and watermark events globally before trying to get or fetch the related conversation, to use it then for the event broadcast on conversation level.
