### PR TITLE
[message_parser] search for closing token

### DIFF
--- a/hangups/message_parser.py
+++ b/hangups/message_parser.py
@@ -8,13 +8,16 @@ from hangups import hangouts_pb2
 
 
 # Common regex patterns
-boundary_chars = r'\s`!()\[\]{{}};:\'".,<>?«»“”‘’*_~='
-b_left = r'(?:(?<=[' + boundary_chars + r'])|(?<=^))'  # Lookbehind
-b_right = r'(?:(?=[' + boundary_chars + r'])|(?=$))'  # Lookahead
+BOUNDARY_CHARS = r'\s`!()\[\]{{}};:\'".,<>?«»“”‘’*_~='
+B_LEFT = r'(?:(?<=[' + BOUNDARY_CHARS + r'])|(?<=^))'  # Lookbehind
+B_RIGHT = r'(?:(?=[' + BOUNDARY_CHARS + r'])|(?=$))'   # Lookahead
+del BOUNDARY_CHARS
 
 # Regex patterns used by token definitions
-markdown_start = b_left + r'(?<!\\){tag}(?!\s)(?!{tag})'
-markdown_end = r'(?<!{tag})(?<!\s)(?<!\\){tag}' + b_right
+MARKDOWN_END = r'(?<![\s\\]){tag}' + B_RIGHT
+MARKDOWN_START = B_LEFT + r'(?<!\\){tag}(?!\s)(?!{tag})(?=.+%s)' % MARKDOWN_END
+del B_LEFT
+del B_RIGHT
 markdown_link = r'(?<!\\)\[(?P<link>.+?)\]\((?P<url>.+?)\)'
 html_start = r'(?i)<{tag}>'
 html_end = r'(?i)</{tag}>'
@@ -43,7 +46,7 @@ markdown_unescape_regex = re.compile(r'\\([*_~=`\[])')
 
 def markdown(tag):
     """Return start and end regex pattern sequences for simple Markdown tag."""
-    return (markdown_start.format(tag=tag), markdown_end.format(tag=tag))
+    return (MARKDOWN_START.format(tag=tag), MARKDOWN_END.format(tag=tag))
 
 
 def html(tag):

--- a/hangups/message_parser.py
+++ b/hangups/message_parser.py
@@ -19,8 +19,8 @@ MARKDOWN_START = B_LEFT + r'(?<!\\){tag}(?!\s)(?!{tag})(?=.+%s)' % MARKDOWN_END
 del B_LEFT
 del B_RIGHT
 markdown_link = r'(?<!\\)\[(?P<link>.+?)\]\((?P<url>.+?)\)'
-html_start = r'(?i)<{tag}>'
-html_end = r'(?i)</{tag}>'
+HTML_END = r'(?i)</{tag}>'
+HTML_START = r'(?i)<{tag}>(?=.+%s)' % HTML_END
 html_link = r'(?i)<a\s+href=[\'"](?P<url>.+?)[\'"]\s*>(?P<link>.+?)</a>'
 html_img = r'(?i)<img\s+src=[\'"](?P<url>.+?)[\'"]\s*/?>'
 html_newline = r'(?i)<br\s*/?>'
@@ -51,7 +51,7 @@ def markdown(tag):
 
 def html(tag):
     """Return sequence of start and end regex patterns for simple HTML tag"""
-    return (html_start.format(tag=tag), html_end.format(tag=tag))
+    return (HTML_START.format(tag=tag), HTML_END.format(tag=tag))
 
 
 def url_complete(url):

--- a/hangups/message_parser.py
+++ b/hangups/message_parser.py
@@ -11,13 +11,10 @@ from hangups import hangouts_pb2
 BOUNDARY_CHARS = r'\s`!()\[\]{{}};:\'".,<>?«»“”‘’*_~='
 B_LEFT = r'(?:(?<=[' + BOUNDARY_CHARS + r'])|(?<=^))'  # Lookbehind
 B_RIGHT = r'(?:(?=[' + BOUNDARY_CHARS + r'])|(?=$))'   # Lookahead
-del BOUNDARY_CHARS
 
 # Regex patterns used by token definitions
 MARKDOWN_END = r'(?<![\s\\]){tag}' + B_RIGHT
 MARKDOWN_START = B_LEFT + r'(?<!\\){tag}(?!\s)(?!{tag})(?=.+%s)' % MARKDOWN_END
-del B_LEFT
-del B_RIGHT
 markdown_link = r'(?<!\\)\[(?P<link>.+?)\]\((?P<url>.+?)\)'
 HTML_END = r'(?i)</{tag}>'
 HTML_START = r'(?i)<{tag}>(?=.+%s)' % HTML_END

--- a/hangups/test/test_message_parser.py
+++ b/hangups/test/test_message_parser.py
@@ -36,7 +36,8 @@ def test_parse_autolinks():
 
 def test_parse_markdown():
     text = ('Test **bold *bolditalic* bold** _italic_ not_italic_not '
-            '~~strike~~ [Google](www.google.com)')
+            '~~strike~~ [Google](www.google.com)'
+            r'**`_bold not italic_`**')
     expected = [('Test ', {}),
                 ('bold ', {'is_bold': True}),
                 ('bolditalic', {'is_bold': True, 'is_italic': True}),
@@ -46,8 +47,12 @@ def test_parse_markdown():
                 (' not_italic_not ', {}),
                 ('strike', {'is_strikethrough': True}),
                 (' ', {}),
-                ('Google', {'link_target': 'http://www.google.com'})]
+                ('Google', {'link_target': 'http://www.google.com'}),
+                ('_bold not italic_', {'is_bold': True})]
     assert expected == parse_text(text)
+
+    text = '*first opened **second opened _third opened __fourth opened'
+    assert [(text, {})] == parse_text(text)
 
 
 def test_parse_html():

--- a/hangups/test/test_message_parser.py
+++ b/hangups/test/test_message_parser.py
@@ -60,7 +60,7 @@ def test_parse_html():
         'Test <b>bold <i>bolditalic</i> bold</b> <em>italic</em> '
         '<del>strike</del><br><a href="google.com">Google</a>'
         '<img src=\'https://upload.wikimedia.org/wikipedia/en/8/80/'
-        'Wikipedia-logo-v2.svg\'>'
+        'Wikipedia-logo-v2.svg\'><i>default'
     )
     expected = [
         ('Test ', {}),
@@ -77,6 +77,7 @@ def test_parse_html():
          'Wikipedia-logo-v2.svg',
          {'link_target':
           'https://upload.wikimedia.org/wikipedia/en/8/80/'
-          'Wikipedia-logo-v2.svg'})
+          'Wikipedia-logo-v2.svg'}),
+        ('<i>default', {}),
     ]
     assert expected == parse_text(text)


### PR DESCRIPTION
This PR adds searching for the closing markdown- or html-tag in each start regex.

Fixes #114 