### PR TITLE
Drop Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 language: python
 python:
-    - '3.4'
     - '3.5'
     - '3.6'
 

--- a/examples/build_conversation_list.py
+++ b/examples/build_conversation_list.py
@@ -1,16 +1,13 @@
 """Example of using hangups.build_user_conversation_list to data."""
 
-import asyncio
-
 import hangups
 
 from common import run_example
 
 
-@asyncio.coroutine
-def sync_recent_conversations(client, _):
+async def sync_recent_conversations(client, _):
     user_list, conversation_list = (
-        yield from hangups.build_user_conversation_list(client)
+        await hangups.build_user_conversation_list(client)
     )
     all_users = user_list.get_all()
     all_conversations = conversation_list.get_all(include_archived=True)

--- a/examples/common.py
+++ b/examples/common.py
@@ -56,8 +56,7 @@ def _get_parser(extra_args):
     return parser
 
 
-@asyncio.coroutine
-def _async_main(example_coroutine, client, args):
+async def _async_main(example_coroutine, client, args):
     """Run the example coroutine."""
     # Spawn a task for hangups to run in parallel with the example coroutine.
     task = asyncio.async(client.connect())
@@ -65,17 +64,17 @@ def _async_main(example_coroutine, client, args):
     # Wait for hangups to either finish connecting or raise an exception.
     on_connect = asyncio.Future()
     client.on_connect.add_observer(lambda: on_connect.set_result(None))
-    done, _ = yield from asyncio.wait(
+    done, _ = await asyncio.wait(
         (on_connect, task), return_when=asyncio.FIRST_COMPLETED
     )
-    yield from asyncio.gather(*done)
+    await asyncio.gather(*done)
 
     # Run the example coroutine. Afterwards, disconnect hangups gracefully and
     # yield the hangups task to handle any exceptions.
     try:
-        yield from example_coroutine(client, args)
+        await example_coroutine(client, args)
     except asyncio.CancelledError:
         pass
     finally:
-        yield from client.disconnect()
-        yield from task
+        await client.disconnect()
+        await task

--- a/examples/common.py
+++ b/examples/common.py
@@ -24,8 +24,9 @@ def run_example(example_coroutine, *extra_args):
     # standard input if necessary.
     cookies = hangups.auth.get_auth_stdin(args.token_path)
     client = hangups.Client(cookies)
-    task = asyncio.async(_async_main(example_coroutine, client, args))
     loop = asyncio.get_event_loop()
+    task = asyncio.ensure_future(_async_main(example_coroutine, client, args),
+                                 loop=loop)
 
     try:
         loop.run_until_complete(task)
@@ -59,7 +60,7 @@ def _get_parser(extra_args):
 async def _async_main(example_coroutine, client, args):
     """Run the example coroutine."""
     # Spawn a task for hangups to run in parallel with the example coroutine.
-    task = asyncio.async(client.connect())
+    task = asyncio.ensure_future(client.connect())
 
     # Wait for hangups to either finish connecting or raise an exception.
     on_connect = asyncio.Future()

--- a/examples/create_group_conversation.py
+++ b/examples/create_group_conversation.py
@@ -1,14 +1,11 @@
 """Example of using hangups to create a new group conversation."""
 
-import asyncio
-
 import hangups
 
 from common import run_example
 
 
-@asyncio.coroutine
-def send_message(client, args):
+async def send_message(client, args):
     request = hangups.hangouts_pb2.CreateConversationRequest(
         request_header=client.get_request_header(),
         type=hangups.hangouts_pb2.CONVERSATION_TYPE_GROUP,
@@ -20,7 +17,7 @@ def send_message(client, args):
         ],
         name=args.conversation_name
     )
-    res = yield from client.create_conversation(request)
+    res = await client.create_conversation(request)
     print(res)
 
 

--- a/examples/enable_group_link_sharing.py
+++ b/examples/enable_group_link_sharing.py
@@ -1,14 +1,11 @@
 """Example of using hangups to enable group link sharing in a conversation."""
 
-import asyncio
-
 import hangups
 
 from common import run_example
 
 
-@asyncio.coroutine
-def enable_group_link_sharing(client, args):
+async def enable_group_link_sharing(client, args):
     request = hangups.hangouts_pb2.SetGroupLinkSharingEnabledRequest(
         request_header=client.get_request_header(),
         event_request_header=hangups.hangouts_pb2.EventRequestHeader(
@@ -21,7 +18,7 @@ def enable_group_link_sharing(client, args):
             hangups.hangouts_pb2.GROUP_LINK_SHARING_STATUS_ON
         ),
     )
-    yield from client.set_group_link_sharing_enabled(request)
+    await client.set_group_link_sharing_enabled(request)
     print('enabled group link sharing for conversation {}'.format(
         args.conversation_id
     ))
@@ -32,7 +29,7 @@ def enable_group_link_sharing(client, args):
             id=args.conversation_id,
         )
     )
-    response = yield from client.get_group_conversation_url(request)
+    response = await client.get_group_conversation_url(request)
     print(response.group_conversation_url)
 
 

--- a/examples/get_conversation.py
+++ b/examples/get_conversation.py
@@ -1,14 +1,11 @@
 """Example of using hangups to get conversation messages."""
 
-import asyncio
-
 import hangups
 
 from common import run_example
 
 
-@asyncio.coroutine
-def get_conversation(client, args):
+async def get_conversation(client, args):
     request = hangups.hangouts_pb2.GetConversationRequest(
         request_header=client.get_request_header(),
         conversation_spec=hangups.hangouts_pb2.ConversationSpec(
@@ -19,7 +16,7 @@ def get_conversation(client, args):
         include_event=True,
         max_events_per_conversation=10,
     )
-    res = yield from client.get_conversation(request)
+    res = await client.get_conversation(request)
     print(res)
 
 

--- a/examples/lookup_entities.py
+++ b/examples/lookup_entities.py
@@ -1,21 +1,18 @@
 """Example of using hangups to lookup entities."""
 
-import asyncio
-
 import hangups
 
 from common import run_example
 
 
-@asyncio.coroutine
-def lookup_entities(client, args):
+async def lookup_entities(client, args):
     """Search for entities by phone number, email, or gaia_id."""
     lookup_spec = _get_lookup_spec(args.entity_identifier)
     request = hangups.hangouts_pb2.GetEntityByIdRequest(
         request_header=client.get_request_header(),
         batch_lookup_spec=[lookup_spec],
     )
-    res = yield from client.get_entity_by_id(request)
+    res = await client.get_entity_by_id(request)
 
     # Print the list of entities in the response.
     for entity_result in res.entity_result:

--- a/examples/query_presence.py
+++ b/examples/query_presence.py
@@ -1,14 +1,11 @@
 """Example of using hangups to query presence of a user."""
 
-import asyncio
-
 import hangups
 
 from common import run_example
 
 
-@asyncio.coroutine
-def query_presence(client, args):
+async def query_presence(client, args):
     request = hangups.hangouts_pb2.QueryPresenceRequest(
         request_header=client.get_request_header(),
         participant_id=[
@@ -22,7 +19,7 @@ def query_presence(client, args):
             hangups.hangouts_pb2.FIELD_MASK_LAST_SEEN,
         ],
     )
-    res = yield from client.query_presence(request)
+    res = await client.query_presence(request)
     print(res)
 
 

--- a/examples/receive_messages.py
+++ b/examples/receive_messages.py
@@ -10,17 +10,16 @@ import hangups
 from common import run_example
 
 
-@asyncio.coroutine
-def receive_messages(client, args):
+async def receive_messages(client, args):
     print('loading conversation list...')
     user_list, conv_list = (
-        yield from hangups.build_user_conversation_list(client)
+        await hangups.build_user_conversation_list(client)
     )
     conv_list.on_event.add_observer(on_event)
 
     print('waiting for chat messages...')
     while True:
-        yield from asyncio.sleep(1)
+        await asyncio.sleep(1)
 
 
 def on_event(conv_event):

--- a/examples/send_map_location.py
+++ b/examples/send_map_location.py
@@ -1,14 +1,11 @@
 """Example of using hangups to send chat message containing a map location."""
 
-import asyncio
-
 import hangups
 
 from common import run_example
 
 
-@asyncio.coroutine
-def send_map_location(client, args):
+async def send_map_location(client, args):
     request = hangups.hangouts_pb2.SendChatMessageRequest(
         request_header=client.get_request_header(),
         event_request_header=hangups.hangouts_pb2.EventRequestHeader(
@@ -34,7 +31,7 @@ def send_map_location(client, args):
             ),
         ),
     )
-    yield from client.send_chat_message(request)
+    await client.send_chat_message(request)
 
 
 if __name__ == '__main__':

--- a/examples/send_message.py
+++ b/examples/send_message.py
@@ -1,14 +1,11 @@
 """Example of using hangups to send a chat message to a conversation."""
 
-import asyncio
-
 import hangups
 
 from common import run_example
 
 
-@asyncio.coroutine
-def send_message(client, args):
+async def send_message(client, args):
     request = hangups.hangouts_pb2.SendChatMessageRequest(
         request_header=client.get_request_header(),
         event_request_header=hangups.hangouts_pb2.EventRequestHeader(
@@ -23,7 +20,7 @@ def send_message(client, args):
             ],
         ),
     )
-    yield from client.send_chat_message(request)
+    await client.send_chat_message(request)
 
 
 if __name__ == '__main__':

--- a/examples/set_focus.py
+++ b/examples/set_focus.py
@@ -1,14 +1,11 @@
 """Example of using hangups to set focus to a conversation."""
 
-import asyncio
-
 import hangups
 
 from common import run_example
 
 
-@asyncio.coroutine
-def set_focus(client, args):
+async def set_focus(client, args):
     request = hangups.hangouts_pb2.SetFocusRequest(
         request_header=client.get_request_header(),
         conversation_id=hangups.hangouts_pb2.ConversationId(
@@ -17,7 +14,7 @@ def set_focus(client, args):
         type=hangups.hangouts_pb2.FOCUS_TYPE_FOCUSED,
         timeout_secs=int(args.timeout_secs),
     )
-    yield from client.set_focus(request)
+    await client.set_focus(request)
 
 
 if __name__ == '__main__':

--- a/examples/suggested_contacts.py
+++ b/examples/suggested_contacts.py
@@ -1,19 +1,16 @@
 """Example of using hangups to retrieve suggested contacts."""
 
-import asyncio
-
 import hangups
 
 from common import run_example
 
 
-@asyncio.coroutine
-def retrieve_suggested_contacts(client, _):
+async def retrieve_suggested_contacts(client, _):
     request = hangups.hangouts_pb2.GetSuggestedEntitiesRequest(
         request_header=client.get_request_header(),
         max_count=100,
     )
-    res = yield from client.get_suggested_entities(request)
+    res = await client.get_suggested_entities(request)
 
     # Print the list of entities in the response.
     for entity in res.entity:

--- a/examples/sync_recent_conversations.py
+++ b/examples/sync_recent_conversations.py
@@ -1,21 +1,18 @@
 """Example of using hangups to get recent conversations."""
 
-import asyncio
-
 import hangups
 
 from common import run_example
 
 
-@asyncio.coroutine
-def sync_recent_conversations(client, _):
+async def sync_recent_conversations(client, _):
     request = hangups.hangouts_pb2.SyncRecentConversationsRequest(
         request_header=client.get_request_header(),
         max_conversations=20,
         max_events_per_conversation=1,
         sync_filter=[hangups.hangouts_pb2.SYNC_FILTER_INBOX],
     )
-    res = yield from client.sync_recent_conversations(request)
+    res = await client.sync_recent_conversations(request)
 
     # Sort the returned conversations by recency.
     conv_states = sorted(

--- a/hangups/channel.py
+++ b/hangups/channel.py
@@ -28,7 +28,6 @@ logger = logging.getLogger(__name__)
 Utf8IncrementalDecoder = codecs.getincrementaldecoder('utf-8')
 LEN_REGEX = re.compile(r'([0-9]+)\n', re.MULTILINE)
 CHANNEL_URL_PREFIX = 'https://0.client-channel.google.com/client-channel/{}'
-CONNECT_TIMEOUT = 30
 # Long-polling requests send heartbeats every 15-30 seconds, so if we miss two
 # in a row, consider the connection dead.
 PUSH_TIMEOUT = 60
@@ -283,11 +282,9 @@ class Channel(object):
         }
         logger.info('Opening new long-polling request')
         try:
-            res = yield from asyncio.wait_for(
-                self._session.fetch_raw(
-                    'GET', CHANNEL_URL_PREFIX.format('channel/bind'),
-                    params=params
-                ), CONNECT_TIMEOUT
+            res = yield from self._session.fetch_raw(
+                'GET', CHANNEL_URL_PREFIX.format('channel/bind'),
+                params=params
             )
 
             try:

--- a/hangups/channel.py
+++ b/hangups/channel.py
@@ -288,8 +288,8 @@ class Channel(object):
                             res.status, res.reason))
 
                 while True:
-                    chunk = await asyncio.wait_for(
-                        res.content.read(MAX_READ_BYTES), PUSH_TIMEOUT)
+                    async with aiohttp.Timeout(PUSH_TIMEOUT):
+                        chunk = await res.content.read(MAX_READ_BYTES)
                     if not chunk:
                         break
 

--- a/hangups/channel.py
+++ b/hangups/channel.py
@@ -166,8 +166,7 @@ class Channel(object):
         """Whether the channel is currently connected."""
         return self._is_connected
 
-    @asyncio.coroutine
-    def listen(self):
+    async def listen(self):
         """Listen for messages on the backwards channel.
 
         This method only returns when the connection has been closed due to an
@@ -182,25 +181,25 @@ class Channel(object):
             if retries > 0:
                 backoff_seconds = self._retry_backoff_base ** retries
                 logger.info('Backing off for %s seconds', backoff_seconds)
-                yield from asyncio.sleep(backoff_seconds)
+                await asyncio.sleep(backoff_seconds)
 
             # Request a new SID if we don't have one yet, or the previous one
             # became invalid.
             if need_new_sid:
-                yield from self._fetch_channel_sid()
+                await self._fetch_channel_sid()
                 need_new_sid = False
             # Clear any previous push data, since if there was an error it
             # could contain garbage.
             self._chunk_parser = ChunkParser()
             try:
-                yield from self._longpoll_request()
+                await self._longpoll_request()
             except (UnknownSIDError, exceptions.NetworkError) as e:
                 logger.warning('Long-polling request failed: {}'.format(e))
                 retries += 1
                 logger.warning('retry attempt count is now {}'.format(retries))
                 if self._is_connected:
                     self._is_connected = False
-                    yield from self.on_disconnect.fire()
+                    await self.on_disconnect.fire()
                 if isinstance(e, UnknownSIDError):
                     need_new_sid = True
             else:
@@ -213,8 +212,7 @@ class Channel(object):
 
         logger.error('Ran out of retries for long-polling request')
 
-    @asyncio.coroutine
-    def send_maps(self, map_list):
+    async def send_maps(self, map_list):
         """Sends a request to the server containing maps (dicts)."""
         params = {
             'VER': 8,  # channel protocol version
@@ -229,7 +227,7 @@ class Channel(object):
         for map_num, map_ in enumerate(map_list):
             for map_key, map_val in map_.items():
                 data_dict['req{}_{}'.format(map_num, map_key)] = map_val
-        res = yield from self._session.fetch(
+        res = await self._session.fetch(
             'post', CHANNEL_URL, params=params, data=data_dict
         )
         return res
@@ -238,8 +236,7 @@ class Channel(object):
     # Private methods
     ##########################################################################
 
-    @asyncio.coroutine
-    def _fetch_channel_sid(self):
+    async def _fetch_channel_sid(self):
         """Creates a new channel for receiving push data.
 
         Sending an empty forward channel request will create a new channel on
@@ -255,13 +252,12 @@ class Channel(object):
         # Set SID and gsessionid to None so they aren't sent in by send_maps.
         self._sid_param = None
         self._gsessionid_param = None
-        res = yield from self.send_maps([])
+        res = await self.send_maps([])
         self._sid_param, self._gsessionid_param = _parse_sid_response(res.body)
         logger.info('New SID: {}'.format(self._sid_param))
         logger.info('New gsessionid: {}'.format(self._gsessionid_param))
 
-    @asyncio.coroutine
-    def _longpoll_request(self):
+    async def _longpoll_request(self):
         """Open a long-polling request and receive arrays.
 
         This method uses keep-alive to make re-opening the request faster, but
@@ -281,7 +277,7 @@ class Channel(object):
         }
         logger.info('Opening new long-polling request')
         try:
-            res = yield from self._session.fetch_raw(
+            res = await self._session.fetch_raw(
                 'GET', CHANNEL_URL, params=params
             )
 
@@ -294,12 +290,12 @@ class Channel(object):
                             res.status, res.reason))
 
                 while True:
-                    chunk = yield from asyncio.wait_for(
+                    chunk = await asyncio.wait_for(
                         res.content.read(MAX_READ_BYTES), PUSH_TIMEOUT)
                     if not chunk:
                         break
 
-                    yield from self._on_push_data(chunk)
+                    await self._on_push_data(chunk)
             finally:
                 res.release()
 
@@ -311,8 +307,7 @@ class Channel(object):
         except aiohttp.ClientError as err:
             raise exceptions.NetworkError('Request connection error: %s' % err)
 
-    @asyncio.coroutine
-    def _on_push_data(self, data_bytes):
+    async def _on_push_data(self, data_bytes):
         """Parse push data and trigger events."""
         logger.debug('Received chunk:\n{}'.format(data_bytes))
         for chunk in self._chunk_parser.get_chunks(data_bytes):
@@ -321,11 +316,11 @@ class Channel(object):
             if not self._is_connected:
                 if self._on_connect_called:
                     self._is_connected = True
-                    yield from self.on_reconnect.fire()
+                    await self.on_reconnect.fire()
                 else:
                     self._on_connect_called = True
                     self._is_connected = True
-                    yield from self.on_connect.fire()
+                    await self.on_connect.fire()
 
             # chunk contains a container array
             container_array = json.loads(chunk)
@@ -336,4 +331,4 @@ class Channel(object):
                 array_id, data_array = inner_array
                 logger.debug('Chunk contains data array with id %r:\n%r',
                              array_id, data_array)
-                yield from self.on_receive_array.fire(data_array)
+                await self.on_receive_array.fire(data_array)

--- a/hangups/channel.py
+++ b/hangups/channel.py
@@ -277,11 +277,9 @@ class Channel(object):
         }
         logger.info('Opening new long-polling request')
         try:
-            res = await self._session.fetch_raw(
-                'GET', CHANNEL_URL, params=params
-            )
+            async with self._session.fetch_raw('GET', CHANNEL_URL,
+                                               params=params) as res:
 
-            try:
                 if res.status != 200:
                     if res.status == 400 and res.reason == 'Unknown SID':
                         raise UnknownSIDError('SID became invalid')
@@ -296,8 +294,6 @@ class Channel(object):
                         break
 
                     await self._on_push_data(chunk)
-            finally:
-                res.release()
 
         except asyncio.TimeoutError:
             raise exceptions.NetworkError('Request timed out')

--- a/hangups/channel.py
+++ b/hangups/channel.py
@@ -27,7 +27,7 @@ from hangups import event, exceptions
 logger = logging.getLogger(__name__)
 Utf8IncrementalDecoder = codecs.getincrementaldecoder('utf-8')
 LEN_REGEX = re.compile(r'([0-9]+)\n', re.MULTILINE)
-CHANNEL_URL_PREFIX = 'https://0.client-channel.google.com/client-channel/{}'
+CHANNEL_URL = 'https://0.client-channel.google.com/client-channel/channel/bind'
 # Long-polling requests send heartbeats every 15-30 seconds, so if we miss two
 # in a row, consider the connection dead.
 PUSH_TIMEOUT = 60
@@ -230,8 +230,7 @@ class Channel(object):
             for map_key, map_val in map_.items():
                 data_dict['req{}_{}'.format(map_num, map_key)] = map_val
         res = yield from self._session.fetch(
-            'post', CHANNEL_URL_PREFIX.format('channel/bind'),
-            params=params, data=data_dict
+            'post', CHANNEL_URL, params=params, data=data_dict
         )
         return res
 
@@ -283,8 +282,7 @@ class Channel(object):
         logger.info('Opening new long-polling request')
         try:
             res = yield from self._session.fetch_raw(
-                'GET', CHANNEL_URL_PREFIX.format('channel/bind'),
-                params=params
+                'GET', CHANNEL_URL, params=params
             )
 
             try:

--- a/hangups/client.py
+++ b/hangups/client.py
@@ -111,8 +111,7 @@ class Client(object):
     # Public methods
     ##########################################################################
 
-    @asyncio.coroutine
-    def connect(self):
+    async def connect(self):
         """Establish a connection to the chat server.
 
         Returns when an error has occurred, or :func:`disconnect` has been
@@ -136,7 +135,7 @@ class Client(object):
             # Listen for StateUpdate messages from the Channel until it
             # disconnects.
             try:
-                yield from self._listen_future
+                await self._listen_future
             except asyncio.CancelledError:
                 # If this task is cancelled, we need to cancel our child task
                 # as well. We don't need an additional yield because listen
@@ -148,8 +147,7 @@ class Client(object):
         finally:
             self._session.close()
 
-    @asyncio.coroutine
-    def disconnect(self):
+    async def disconnect(self):
         """Gracefully disconnect from the server.
 
         When disconnection is complete, :func:`connect` will return.
@@ -180,8 +178,7 @@ class Client(object):
         """
         return random.randint(0, 2**32)
 
-    @asyncio.coroutine
-    def set_active(self):
+    async def set_active(self):
         """Set this client as active.
 
         While a client is active, no other clients will raise notifications.
@@ -208,7 +205,7 @@ class Client(object):
                     get_self_info_request = hangouts_pb2.GetSelfInfoRequest(
                         request_header=self.get_request_header(),
                     )
-                    get_self_info_response = yield from self.get_self_info(
+                    get_self_info_response = await self.get_self_info(
                         get_self_info_request
                     )
                 except exceptions.NetworkError as e:
@@ -234,16 +231,15 @@ class Client(object):
                     full_jid="{}/{}".format(self._email, self._client_id),
                     timeout_secs=ACTIVE_TIMEOUT_SECS,
                 )
-                yield from self.set_active_client(set_active_request)
+                await self.set_active_client(set_active_request)
             except exceptions.NetworkError as e:
                 logger.warning('Failed to set active client: {}'.format(e))
             else:
                 logger.info('Set active client for {} seconds'
                             .format(ACTIVE_TIMEOUT_SECS))
 
-    @asyncio.coroutine
-    def upload_image(self, image_file, filename=None, *,
-                     return_uploaded_image=False):
+    async def upload_image(self, image_file, filename=None, *,
+                           return_uploaded_image=False):
         """Upload an image that can be later attached to a chat message.
 
         Args:
@@ -262,7 +258,7 @@ class Client(object):
         image_data = image_file.read()
 
         # request an upload URL
-        res = yield from self._base_request(
+        res = await self._base_request(
             IMAGE_UPLOAD_URL,
             'application/x-www-form-urlencoded;charset=UTF-8', 'json',
             json.dumps({
@@ -290,7 +286,7 @@ class Client(object):
             )
 
         # upload the image data using the upload_url to get the upload info
-        res = yield from self._base_request(
+        res = await self._base_request(
             upload_url, 'application/octet-stream', 'json', image_data
         )
 
@@ -343,8 +339,7 @@ class Client(object):
             ))
         return response['sessionStatus']
 
-    @asyncio.coroutine
-    def _on_receive_array(self, array):
+    async def _on_receive_array(self, array):
         """Parse channel array and call the appropriate events."""
         if array[0] == 'noop':
             pass  # This is just a keep-alive, ignore it.
@@ -359,7 +354,7 @@ class Client(object):
                 logger.info('Received new client_id: %r', self._client_id)
                 # Once client_id is received, the channel is ready to have
                 # services added.
-                yield from self._add_channel_services()
+                await self._add_channel_services()
             if '2' in wrapper:
                 pblite_message = json.loads(wrapper['2']['2'])
                 if pblite_message[0] == 'cbu':
@@ -372,12 +367,11 @@ class Client(object):
                         logger.debug('Received StateUpdate:\n%s', state_update)
                         header = state_update.state_update_header
                         self._active_client_state = header.active_client_state
-                        yield from self.on_state_update.fire(state_update)
+                        await self.on_state_update.fire(state_update)
                 else:
                     logger.info('Ignoring message: %r', pblite_message[0])
 
-    @asyncio.coroutine
-    def _add_channel_services(self):
+    async def _add_channel_services(self):
         """Add services to the channel.
 
         The services we add to the channel determine what kind of data we will
@@ -400,11 +394,10 @@ class Client(object):
             dict(p=json.dumps({"3": {"1": {"1": service}}}))
             for service in services
         ]
-        yield from self._channel.send_maps(map_list)
+        await self._channel.send_maps(map_list)
         logger.info('Channel services added')
 
-    @asyncio.coroutine
-    def _pb_request(self, endpoint, request_pb, response_pb):
+    async def _pb_request(self, endpoint, request_pb, response_pb):
         """Send a Protocol Buffer formatted chat API request.
 
         Args:
@@ -417,7 +410,7 @@ class Client(object):
         """
         logger.debug('Sending Protocol Buffer request %s:\n%s', endpoint,
                      request_pb)
-        res = yield from self._base_request(
+        res = await self._base_request(
             'https://clients6.google.com/chat/v1/{}'.format(endpoint),
             'application/x-protobuf',  # Request body is Protocol Buffer.
             'proto',  # Response body is Protocol Buffer.
@@ -442,8 +435,7 @@ class Client(object):
                 .format(status, description)
             )
 
-    @asyncio.coroutine
-    def _base_request(self, url, content_type, response_type, data):
+    async def _base_request(self, url, content_type, response_type, data):
         """Send a generic authenticated POST request.
 
         Args:
@@ -474,7 +466,7 @@ class Client(object):
             # Unauthenticated Use Exceeded. Continued use requires signup").
             'key': API_KEY,
         }
-        res = yield from self._session.fetch(
+        res = await self._session.fetch(
             'post', url, headers=headers, params=params, data=data,
         )
         return res
@@ -484,24 +476,21 @@ class Client(object):
     # particular APIs.
     ###########################################################################
 
-    @asyncio.coroutine
-    def add_user(self, add_user_request):
+    async def add_user(self, add_user_request):
         """Invite users to join an existing group conversation."""
         response = hangouts_pb2.AddUserResponse()
-        yield from self._pb_request('conversations/adduser',
-                                    add_user_request, response)
+        await self._pb_request('conversations/adduser',
+                               add_user_request, response)
         return response
 
-    @asyncio.coroutine
-    def create_conversation(self, create_conversation_request):
+    async def create_conversation(self, create_conversation_request):
         """Create a new conversation."""
         response = hangouts_pb2.CreateConversationResponse()
-        yield from self._pb_request('conversations/createconversation',
-                                    create_conversation_request, response)
+        await self._pb_request('conversations/createconversation',
+                               create_conversation_request, response)
         return response
 
-    @asyncio.coroutine
-    def delete_conversation(self, delete_conversation_request):
+    async def delete_conversation(self, delete_conversation_request):
         """Leave a one-to-one conversation.
 
         One-to-one conversations are "sticky"; they can't actually be deleted.
@@ -509,28 +498,25 @@ class Client(object):
         ``delete_upper_bound_timestamp``, hiding it if no events remain.
         """
         response = hangouts_pb2.DeleteConversationResponse()
-        yield from self._pb_request('conversations/deleteconversation',
-                                    delete_conversation_request, response)
+        await self._pb_request('conversations/deleteconversation',
+                               delete_conversation_request, response)
         return response
 
-    @asyncio.coroutine
-    def easter_egg(self, easter_egg_request):
+    async def easter_egg(self, easter_egg_request):
         """Send an easter egg event to a conversation."""
         response = hangouts_pb2.EasterEggResponse()
-        yield from self._pb_request('conversations/easteregg',
-                                    easter_egg_request, response)
+        await self._pb_request('conversations/easteregg',
+                               easter_egg_request, response)
         return response
 
-    @asyncio.coroutine
-    def get_conversation(self, get_conversation_request):
+    async def get_conversation(self, get_conversation_request):
         """Return conversation info and recent events."""
         response = hangouts_pb2.GetConversationResponse()
-        yield from self._pb_request('conversations/getconversation',
-                                    get_conversation_request, response)
+        await self._pb_request('conversations/getconversation',
+                               get_conversation_request, response)
         return response
 
-    @asyncio.coroutine
-    def get_entity_by_id(self, get_entity_by_id_request):
+    async def get_entity_by_id(self, get_entity_by_id_request):
         """Return one or more user entities.
 
         Searching by phone number only finds entities when their phone number
@@ -538,52 +524,48 @@ class Client(object):
         find Google Voice contacts.
         """
         response = hangouts_pb2.GetEntityByIdResponse()
-        yield from self._pb_request('contacts/getentitybyid',
-                                    get_entity_by_id_request, response)
+        await self._pb_request('contacts/getentitybyid',
+                               get_entity_by_id_request, response)
         return response
 
-    def get_group_conversation_url(self, get_group_conversation_url_request):
+    async def get_group_conversation_url(self,
+                                         get_group_conversation_url_request):
         """Get URL to allow others to join a group conversation."""
         response = hangouts_pb2.GetGroupConversationUrlResponse()
-        yield from self._pb_request('conversations/getgroupconversationurl',
-                                    get_group_conversation_url_request,
-                                    response)
+        await self._pb_request('conversations/getgroupconversationurl',
+                               get_group_conversation_url_request,
+                               response)
         return response
 
-    @asyncio.coroutine
-    def get_self_info(self, get_self_info_request):
+    async def get_self_info(self, get_self_info_request):
         """Return info about the current user."""
         response = hangouts_pb2.GetSelfInfoResponse()
-        yield from self._pb_request('contacts/getselfinfo',
-                                    get_self_info_request, response)
+        await self._pb_request('contacts/getselfinfo',
+                               get_self_info_request, response)
         return response
 
-    @asyncio.coroutine
-    def get_suggested_entities(self, get_suggested_entities_request):
+    async def get_suggested_entities(self, get_suggested_entities_request):
         """Return suggested contacts."""
         response = hangouts_pb2.GetSuggestedEntitiesResponse()
-        yield from self._pb_request('contacts/getsuggestedentities',
-                                    get_suggested_entities_request, response)
+        await self._pb_request('contacts/getsuggestedentities',
+                               get_suggested_entities_request, response)
         return response
 
-    @asyncio.coroutine
-    def query_presence(self, query_presence_request):
+    async def query_presence(self, query_presence_request):
         """Return presence status for a list of users."""
         response = hangouts_pb2.QueryPresenceResponse()
-        yield from self._pb_request('presence/querypresence',
-                                    query_presence_request, response)
+        await self._pb_request('presence/querypresence',
+                               query_presence_request, response)
         return response
 
-    @asyncio.coroutine
-    def remove_user(self, remove_user_request):
+    async def remove_user(self, remove_user_request):
         """Remove a participant from a group conversation."""
         response = hangouts_pb2.RemoveUserResponse()
-        yield from self._pb_request('conversations/removeuser',
-                                    remove_user_request, response)
+        await self._pb_request('conversations/removeuser',
+                               remove_user_request, response)
         return response
 
-    @asyncio.coroutine
-    def rename_conversation(self, rename_conversation_request):
+    async def rename_conversation(self, rename_conversation_request):
         """Rename a conversation.
 
         Both group and one-to-one conversations may be renamed, but the
@@ -591,120 +573,112 @@ class Client(object):
         conversations with custom names.
         """
         response = hangouts_pb2.RenameConversationResponse()
-        yield from self._pb_request('conversations/renameconversation',
-                                    rename_conversation_request, response)
+        await self._pb_request('conversations/renameconversation',
+                               rename_conversation_request, response)
         return response
 
-    @asyncio.coroutine
-    def search_entities(self, search_entities_request):
+    async def search_entities(self, search_entities_request):
         """Return user entities based on a query."""
         response = hangouts_pb2.SearchEntitiesResponse()
-        yield from self._pb_request('contacts/searchentities',
-                                    search_entities_request, response)
+        await self._pb_request('contacts/searchentities',
+                               search_entities_request, response)
         return response
 
-    @asyncio.coroutine
-    def send_chat_message(self, send_chat_message_request):
+    async def send_chat_message(self, send_chat_message_request):
         """Send a chat message to a conversation."""
         response = hangouts_pb2.SendChatMessageResponse()
-        yield from self._pb_request('conversations/sendchatmessage',
-                                    send_chat_message_request, response)
+        await self._pb_request('conversations/sendchatmessage',
+                               send_chat_message_request, response)
         return response
 
-    @asyncio.coroutine
-    def modify_otr_status(self, modify_otr_status_request):
+    async def modify_otr_status(self, modify_otr_status_request):
         """Enable or disable message history in a conversation."""
         response = hangouts_pb2.ModifyOTRStatusResponse()
-        yield from self._pb_request('conversations/modifyotrstatus',
-                                    modify_otr_status_request, response)
+        await self._pb_request('conversations/modifyotrstatus',
+                               modify_otr_status_request, response)
         return response
 
-    @asyncio.coroutine
-    def send_offnetwork_invitation(self, send_offnetwork_invitation_request):
+    async def send_offnetwork_invitation(
+            self, send_offnetwork_invitation_request
+    ):
         """Send an email to invite a non-Google contact to Hangouts."""
         response = hangouts_pb2.SendOffnetworkInvitationResponse()
-        yield from self._pb_request('devices/sendoffnetworkinvitation',
-                                    send_offnetwork_invitation_request,
-                                    response)
+        await self._pb_request('devices/sendoffnetworkinvitation',
+                               send_offnetwork_invitation_request,
+                               response)
         return response
 
-    @asyncio.coroutine
-    def set_active_client(self, set_active_client_request):
+    async def set_active_client(self, set_active_client_request):
         """Set the active client."""
         response = hangouts_pb2.SetActiveClientResponse()
-        yield from self._pb_request('clients/setactiveclient',
-                                    set_active_client_request, response)
+        await self._pb_request('clients/setactiveclient',
+                               set_active_client_request, response)
         return response
 
-    @asyncio.coroutine
-    def set_conversation_notification_level(
+    async def set_conversation_notification_level(
             self, set_conversation_notification_level_request
     ):
         """Set the notification level of a conversation."""
         response = hangouts_pb2.SetConversationNotificationLevelResponse()
-        yield from self._pb_request(
+        await self._pb_request(
             'conversations/setconversationnotificationlevel',
             set_conversation_notification_level_request, response
         )
         return response
 
-    @asyncio.coroutine
-    def set_focus(self, set_focus_request):
+    async def set_focus(self, set_focus_request):
         """Set focus to a conversation."""
         response = hangouts_pb2.SetFocusResponse()
-        yield from self._pb_request('conversations/setfocus',
-                                    set_focus_request, response)
+        await self._pb_request('conversations/setfocus',
+                               set_focus_request, response)
         return response
 
-    @asyncio.coroutine
-    def set_group_link_sharing_enabled(self,
-                                       set_group_link_sharing_enabled_request):
+    async def set_group_link_sharing_enabled(
+            self, set_group_link_sharing_enabled_request
+    ):
         """Set whether group link sharing is enabled for a conversation."""
         response = hangouts_pb2.SetGroupLinkSharingEnabledResponse()
-        yield from self._pb_request('conversations/setgrouplinksharingenabled',
-                                    set_group_link_sharing_enabled_request,
-                                    response)
+        await self._pb_request('conversations/setgrouplinksharingenabled',
+                               set_group_link_sharing_enabled_request,
+                               response)
         return response
 
-    @asyncio.coroutine
-    def set_presence(self, set_presence_request):
+    async def set_presence(self, set_presence_request):
         """Set the presence status."""
         response = hangouts_pb2.SetPresenceResponse()
-        yield from self._pb_request('presence/setpresence',
-                                    set_presence_request, response)
+        await self._pb_request('presence/setpresence',
+                               set_presence_request, response)
         return response
 
-    @asyncio.coroutine
-    def set_typing(self, set_typing_request):
+    async def set_typing(self, set_typing_request):
         """Set the typing status of a conversation."""
         response = hangouts_pb2.SetTypingResponse()
-        yield from self._pb_request('conversations/settyping',
-                                    set_typing_request, response)
+        await self._pb_request('conversations/settyping',
+                               set_typing_request, response)
         return response
 
-    @asyncio.coroutine
-    def sync_all_new_events(self, sync_all_new_events_request):
+    async def sync_all_new_events(self, sync_all_new_events_request):
         """List all events occurring at or after a timestamp."""
         response = hangouts_pb2.SyncAllNewEventsResponse()
-        yield from self._pb_request('conversations/syncallnewevents',
-                                    sync_all_new_events_request, response)
+        await self._pb_request('conversations/syncallnewevents',
+                               sync_all_new_events_request, response)
         return response
 
-    @asyncio.coroutine
-    def sync_recent_conversations(self, sync_recent_conversations_request):
+    async def sync_recent_conversations(
+            self, sync_recent_conversations_request
+    ):
         """Return info on recent conversations and their events."""
         response = hangouts_pb2.SyncRecentConversationsResponse()
-        yield from self._pb_request('conversations/syncrecentconversations',
-                                    sync_recent_conversations_request,
-                                    response)
+        await self._pb_request('conversations/syncrecentconversations',
+                               sync_recent_conversations_request,
+                               response)
         return response
 
-    @asyncio.coroutine
-    def update_watermark(self, update_watermark_request):
+    async def update_watermark(self, update_watermark_request):
         """Update the watermark (read timestamp) of a conversation."""
         response = hangouts_pb2.UpdateWatermarkResponse()
-        yield from self._pb_request('conversations/updatewatermark',
-                                    update_watermark_request, response)
+        await self._pb_request('conversations/updatewatermark',
+                               update_watermark_request, response)
         return response
 
 

--- a/hangups/client.py
+++ b/hangups/client.py
@@ -131,7 +131,7 @@ class Client(object):
             self._channel.on_receive_array.add_observer(self._on_receive_array)
 
             # Wrap the coroutine in a Future so it can be cancelled.
-            self._listen_future = asyncio.async(self._channel.listen())
+            self._listen_future = asyncio.ensure_future(self._channel.listen())
             # Listen for StateUpdate messages from the Channel until it
             # disconnects.
             try:

--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -413,7 +413,7 @@ class Conversation(object):
         Raises:
             .NetworkError: If the message cannot be sent.
         """
-        with (await self._send_message_lock):
+        async with self._send_message_lock:
             if image_file:
                 try:
                     uploaded_image = await self._client.upload_image(

--- a/hangups/event.py
+++ b/hangups/event.py
@@ -50,14 +50,13 @@ class Event(object):
                              .format(callback, self))
         self._observers.remove(callback)
 
-    @asyncio.coroutine
-    def fire(self, *args, **kwargs):
+    async def fire(self, *args, **kwargs):
         """Fire this event, calling all observers with the same arguments."""
         logger.debug('Fired {}'.format(self))
         for observer in self._observers:
             gen = observer(*args, **kwargs)
             if asyncio.iscoroutinefunction(observer):
-                yield from gen
+                await gen
 
     def __repr__(self):
         return 'Event(\'{}\')'.format(self._name)

--- a/hangups/http_utils.py
+++ b/hangups/http_utils.py
@@ -29,7 +29,8 @@ class Session(object):
 
     def __init__(self, cookies, proxy=None):
         self._proxy = proxy
-        self._session = aiohttp.ClientSession(cookies=cookies)
+        self._session = aiohttp.ClientSession(cookies=cookies,
+                                              conn_timeout=CONNECT_TIMEOUT)
         sapisid = cookies['SAPISID']
         self._authorization_headers = _get_authorization_headers(sapisid)
 
@@ -58,11 +59,9 @@ class Session(object):
         logger.debug('Sending request %s %s:\n%r', method, url, data)
         for retry_num in range(MAX_RETRIES):
             try:
-                res = yield from asyncio.wait_for(
-                    self.fetch_raw(
+                res = yield from self.fetch_raw(
                         method, url, params=params, headers=headers, data=data,
-                    ),
-                    CONNECT_TIMEOUT)
+                    )
                 try:
                     body = yield from asyncio.wait_for(
                         res.read(), REQUEST_TIMEOUT)

--- a/hangups/http_utils.py
+++ b/hangups/http_utils.py
@@ -34,8 +34,7 @@ class Session(object):
         sapisid = cookies['SAPISID']
         self._authorization_headers = _get_authorization_headers(sapisid)
 
-    @asyncio.coroutine
-    def fetch(self, method, url, params=None, headers=None, data=None):
+    async def fetch(self, method, url, params=None, headers=None, data=None):
         """Make an HTTP request.
 
         Automatically uses configured HTTP proxy, and adds Google authorization
@@ -59,11 +58,11 @@ class Session(object):
         logger.debug('Sending request %s %s:\n%r', method, url, data)
         for retry_num in range(MAX_RETRIES):
             try:
-                res = yield from self.fetch_raw(
+                res = await self.fetch_raw(
                         method, url, params=params, headers=headers, data=data,
                     )
                 try:
-                    body = yield from asyncio.wait_for(
+                    body = await asyncio.wait_for(
                         res.read(), REQUEST_TIMEOUT)
                 finally:
                     res.release()
@@ -92,8 +91,8 @@ class Session(object):
 
         return FetchResponse(res.status, body)
 
-    @asyncio.coroutine
-    def fetch_raw(self, method, url, params=None, headers=None, data=None):
+    async def fetch_raw(self, method, url,
+                        params=None, headers=None, data=None):
         """Make an HTTP request using aiohttp directly.
 
         Automatically uses configured HTTP proxy, and adds Google authorization
@@ -119,7 +118,7 @@ class Session(object):
 
         headers = headers or {}
         headers.update(self._authorization_headers)
-        return (yield from self._session.request(
+        return (await self._session.request(
             method, url, params=params, headers=headers, data=data,
             proxy=self._proxy
         ))

--- a/hangups/http_utils.py
+++ b/hangups/http_utils.py
@@ -60,8 +60,8 @@ class Session(object):
             try:
                 async with self.fetch_raw(method, url, params=params,
                                           headers=headers, data=data) as res:
-                    body = await asyncio.wait_for(
-                        res.read(), REQUEST_TIMEOUT)
+                    async with aiohttp.Timeout(REQUEST_TIMEOUT):
+                        body = await res.read()
                 logger.debug('Received response %d %s:\n%r',
                              res.status, res.reason, body)
             except asyncio.TimeoutError:

--- a/hangups/test/test_event.py
+++ b/hangups/test/test_event.py
@@ -6,10 +6,9 @@ import pytest
 from hangups import event
 
 
-def coroutine_test(f):
+def coroutine_test(coro):
     """Decorator to create a coroutine that starts and stops its own loop."""
     def wrapper(*args, **kwargs):
-        coro = asyncio.coroutine(f)
         future = coro(*args, **kwargs)
         loop = asyncio.new_event_loop()
         loop.run_until_complete(future)
@@ -17,38 +16,38 @@ def coroutine_test(f):
 
 
 @coroutine_test
-def test_event():
+async def test_event():
     e = event.Event('MyEvent')
     res = []
     a = asyncio.coroutine(lambda arg: res.append('a' + arg))
     b = asyncio.coroutine(lambda arg: res.append('b' + arg))
     e.add_observer(a)
-    yield from e.fire('1')
+    await e.fire('1')
     e.add_observer(b)
-    yield from e.fire('2')
+    await e.fire('2')
     e.remove_observer(a)
-    yield from e.fire('3')
+    await e.fire('3')
     e.remove_observer(b)
-    yield from e.fire('4')
+    await e.fire('4')
     assert res == ['a1', 'a2', 'b2', 'b3']
 
 
 @coroutine_test
-def test_function_observer():
+async def test_function_observer():
     e = event.Event('MyEvent')
     res = []
     e.add_observer(lambda arg: res.append('a' + arg))
-    yield from e.fire('1')
+    await e.fire('1')
     assert res == ['a1']
 
 
 @coroutine_test
-def test_coroutine_observer():
+async def test_coroutine_observer():
     e = event.Event('MyEvent')
     res = []
     a = asyncio.coroutine(lambda arg: res.append('a' + arg))
     e.add_observer(a)
-    yield from e.fire('1')
+    await e.fire('1')
     assert res == ['a1']
 
 

--- a/hangups/ui/__main__.py
+++ b/hangups/ui/__main__.py
@@ -250,7 +250,7 @@ class CoroutineQueue:
     This creates a problem if we need to execute a coroutine in response to
     user input.
 
-    One option is to use asyncio.async to execute a "fire and forget"
+    One option is to use asyncio.ensure_future to execute a "fire and forget"
     coroutine. If we do this, exceptions will be logged instead of propagated,
     which can obscure problems.
 

--- a/hangups/ui/__main__.py
+++ b/hangups/ui/__main__.py
@@ -143,9 +143,8 @@ class ChatUI(object):
                 self._exc_info[1]
             ).with_traceback(self._exc_info[2])
 
-    @asyncio.coroutine
-    def _connect(self):
-        yield from self._client.connect()
+    async def _connect(self):
+        await self._client.connect()
         raise HangupsDisconnected()
 
     def _exception_handler(self, _loop, _context):
@@ -208,11 +207,10 @@ class ChatUI(object):
         # switch to new or existing tab for the conversation
         self.add_conversation_tab(conv_id, switch=True)
 
-    @asyncio.coroutine
-    def _on_connect(self):
+    async def _on_connect(self):
         """Handle connecting for the first time."""
         self._user_list, self._conv_list = (
-            yield from hangups.build_user_conversation_list(self._client)
+            await hangups.build_user_conversation_list(self._client)
         )
         self._conv_list.on_event.add_observer(self._on_event)
 
@@ -271,13 +269,12 @@ class CoroutineQueue:
         assert asyncio.iscoroutine(coro)
         self._queue.put_nowait(coro)
 
-    @asyncio.coroutine
-    def consume(self):
+    async def consume(self):
         """Consume coroutines from the queue by executing them."""
         while True:
-            coro = yield from self._queue.get()
+            coro = await self._queue.get()
             assert asyncio.iscoroutine(coro)
-            yield from coro
+            await coro
 
 
 class WidgetBase(urwid.WidgetWrap):
@@ -704,11 +701,10 @@ class ConversationEventListWalker(urwid.ListWalker):
         else:
             self._modified()
 
-    @asyncio.coroutine
-    def _load(self):
+    async def _load(self):
         """Load more events for this conversation."""
         try:
-            conv_events = yield from self._conversation.get_events(
+            conv_events = await self._conversation.get_events(
                 self._conversation.events[0].id_
             )
         except (IndexError, hangups.NetworkError):
@@ -882,11 +878,10 @@ class ConversationWidget(WidgetBase):
             )
         )
 
-    @asyncio.coroutine
-    def _handle_send_message(self, coro):
+    async def _handle_send_message(self, coro):
         """Handle showing an error if a message fails to send."""
         try:
-            yield from coro
+            await coro
         except hangups.NetworkError:
             self._status_widget.show_message('Failed to send message')
 

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,10 @@ import os
 import sys
 
 
-if sys.version_info < (3, 4, 2):
-    # This is the minimum version supported by aiohttp.
-    raise RuntimeError("hangups requires Python 3.4.2+")
+if sys.version_info < (3, 5):
+    # This is the minimum version which has support for `async def`/`await`/
+    # `async with` syntax.
+    raise RuntimeError("hangups requires Python 3.5+")
 
 
 # Find __version__ without import that requires dependencies to be installed:


### PR DESCRIPTION
Fix #379 

By dropping Python 3.4 we can now use `async def` / `await` syntax https://github.com/tdryer/hangups/commit/2624197a237e2a96ddaf3fa879afe0fe587896a7.

In addition I refactored the cleanup of http requests https://github.com/tdryer/hangups/commit/363e1aced10456571cae7c520105ee8b747fb993 and the read/push timeout handling https://github.com/tdryer/hangups/commit/498f0cbc84a195e80ccf009f3f9e9118f451cd40 into context manager.
Talking about timeouts: `aiohttp` can handle the connect timeout internally https://github.com/tdryer/hangups/commit/77929844cd9666f6e0121c1b2265e0d4843b4732.