### PR TITLE
[ui] extend the check for a previously raised exception

### DIFF
--- a/hangups/ui/__main__.py
+++ b/hangups/ui/__main__.py
@@ -138,7 +138,7 @@ class ChatUI(object):
 
         # If an exception was stored, raise it now. This is used for exceptions
         # originating in urwid callbacks.
-        if self._exc_info:
+        if self._exc_info and self._exc_info[0] is not None:
             raise self._exc_info[0](
                 self._exc_info[1]
             ).with_traceback(self._exc_info[2])


### PR DESCRIPTION
As [per the docs](https://docs.python.org/3/library/sys.html?highlight=exc_info#sys.exc_info) `sys.exc_info()` may return a tuple of three `None`type values in case there was no previous exception raised.

Possible fix for #384 