### PR TITLE
properly await on aiohttp.ClientSession.close()

### DIFF
--- a/hangups/client.py
+++ b/hangups/client.py
@@ -145,7 +145,7 @@ class Client(object):
                 'Client.connect returning because Channel.listen returned'
             )
         finally:
-            self._session.close()
+            await self._session.close()
 
     async def disconnect(self):
         """Gracefully disconnect from the server.

--- a/hangups/http_utils.py
+++ b/hangups/http_utils.py
@@ -118,9 +118,9 @@ class Session(object):
             proxy=self._proxy
         )
 
-    def close(self):
+    async def close(self):
         """Close the underlying aiohttp.ClientSession."""
-        self._session.close()
+        await self._session.close()
 
 
 def _get_authorization_headers(sapisid_cookie):


### PR DESCRIPTION
It looks like there was a typo in aiohttp (aio-libs/aiohttp#2029) and if the warning was heeded then a bug was introduced