### PR TITLE
upgrade protobuf version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
     'readlike==0.1.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)
     'ReParser==1.4.3',
-    'protobuf>=3.1.0,<3.2.0',
+    'protobuf>=3.4.0',
     'urwid==1.3.1',
     'MechanicalSoup==0.6.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
     'readlike==0.1.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)
     'ReParser==1.4.3',
-    'protobuf>=3.1.0',
+    'protobuf>=3.1.0,<=3.6.1',
     'urwid==1.3.1',
     'MechanicalSoup==0.6.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
     'readlike==0.1.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)
     'ReParser==1.4.3',
-    'protobuf>=3.4.0',
+    'protobuf>=3.1.0',
     'urwid==1.3.1',
     'MechanicalSoup==0.6.0',
 ]


### PR DESCRIPTION
No new tests fail, and the example client seems to work fine.

I need to use hangups in a project that has other dependencies that require higher versions of protobuf.