### PR TITLE
Add participant watermarks to Conversation objects and in ChatUI. 

### DIFF
--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -3,7 +3,6 @@
 import asyncio
 import datetime
 import logging
-from typing import Dict
 
 from hangups import (parsers, event, user, conversation_event, exceptions,
                      hangouts_pb2)
@@ -133,7 +132,6 @@ class Conversation(object):
 
     Use :class:`.ConversationList` methods to get instances of this class.
     """
-    _watermarks: Dict[user.UserID, datetime.datetime]
 
     def __init__(self, client, user_list, conversation, events=[]):
         # pylint: disable=dangerous-default-value

--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -658,6 +658,12 @@ class Conversation(object):
                         )
                     )
                 )
+                # Certain fields of conversation_state are not populated
+                # by SyncRecentConversations. This is the case with the
+                # user_read_state fields which are all set to 0 but
+                # for the 'self' user.
+                # It seems these fields get populated on the first call
+                # to GetConversation, so we update here.
                 if res.conversation_state.HasField('conversation'):
                     self.update_conversation(
                         res.conversation_state.conversation

--- a/hangups/parsers.py
+++ b/hangups/parsers.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 import datetime
 import logging
 
-from hangups import user
+from hangups import user, hangouts_pb2
 
 
 logger = logging.getLogger(__name__)
@@ -28,6 +28,19 @@ def to_timestamp(datetime_timestamp):
     """Convert UTC datetime to microsecond timestamp used by Hangouts."""
     return int(datetime_timestamp.timestamp() * 1000000)
 
+
+def from_participantid(participant_id: hangouts_pb2.ParticipantId):
+    return user.UserID(
+        chat_id=participant_id.chat_id,
+        gaia_id=participant_id.gaia_id
+    )
+
+
+def to_participantid(user_id: user.UserID):
+    return hangouts_pb2.ParticipantId(
+        chat_id=user_id.chat_id,
+        gaia_id=user_id.gaia_id
+    )
 
 ##############################################################################
 # Message types and parsers
@@ -58,8 +71,7 @@ def parse_typing_status_message(p):
     """
     return TypingStatusMessage(
         conv_id=p.conversation_id.id,
-        user_id=user.UserID(chat_id=p.sender_id.chat_id,
-                            gaia_id=p.sender_id.gaia_id),
+        user_id=from_participantid(p.sender_id),
         timestamp=from_timestamp(p.timestamp),
         status=p.type,
     )
@@ -81,10 +93,7 @@ def parse_watermark_notification(p):
     """Return WatermarkNotification from hangouts_pb2.WatermarkNotification."""
     return WatermarkNotification(
         conv_id=p.conversation_id.id,
-        user_id=user.UserID(
-            chat_id=p.sender_id.chat_id,
-            gaia_id=p.sender_id.gaia_id,
-        ),
+        user_id=from_participantid(p.sender_id),
         read_timestamp=from_timestamp(
             p.latest_read_timestamp
         ),

--- a/hangups/ui/__main__.py
+++ b/hangups/ui/__main__.py
@@ -9,6 +9,7 @@ import os
 import sys
 import urwid
 import readlike
+from bisect import bisect
 
 import hangups
 from hangups.ui.emoticon import replace_emoticons
@@ -789,7 +790,6 @@ class ConversationEventListWalker(urwid.ListWalker):
             if user.is_self:
                 continue
             timestamp = self._conversation.watermarks[user_id]
-            from bisect import bisect
             event_idx = bisect(timestamps, timestamp) - 1
             if event_idx >= 0:
                 event_pos = self._conversation.events[event_idx].id_

--- a/hangups/ui/__main__.py
+++ b/hangups/ui/__main__.py
@@ -1,5 +1,4 @@
 """Reference chat client for hangups."""
-from typing import Dict, Set
 
 import appdirs
 import asyncio
@@ -696,7 +695,6 @@ class ConversationEventListWalker(urwid.ListWalker):
     """
 
     POSITION_LOADING = 'loading'
-    _watermarked_events = Dict[str, Set[hangups.user.User]]
 
     def __init__(self, coroutine_queue, conversation, datetimefmt):
         self._coroutine_queue = coroutine_queue  # CoroutineQueue

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ lazy-object-proxy==1.3.1  # via astroid
 mccabe==0.6.1             # via pylint
 pip-tools==1.9.0
 py==1.4.34                # via pytest
-pycodestyle==2.2.0
+pycodestyle==2.4.0
 pylint==1.7.2
 pytest==3.1.3
 six==1.10.0               # via astroid, pip-tools, pylint


### PR DESCRIPTION
 - Adds the `watermarks` property to `Conversation` objects offering a dictionary of timestamps for each `user_id`, identifying the most recent read for each conversation participant.

 - Appends a `[ Seen by <> ]` footer to the last event(s) seen by one or more participants in a conversation view. Footers are updated on `WatermarkNotification`s.

 - Should facilitate #171 .