### PR TITLE
[message_parser] start over with a new auto link pattern

### DIFF
--- a/hangups/message_parser.py
+++ b/hangups/message_parser.py
@@ -23,16 +23,50 @@ html_img = r'(?i)<img\s+src=[\'"](?P<url>.+?)[\'"]\s*/?>'
 html_newline = r'(?i)<br\s*/?>'
 newline = r'\n|\r\n'
 
-# Based on URL regex pattern by John Gruber
-# (http://gist.github.com/gruber/249502)
-auto_link = (
-    r'(?i)\b('
-    r'(?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|'
-    r'[a-z0-9.\-]+[.][a-z]{2,4}/)'
-    r'(?:[^\s()<>]|\((?:[^\s()<>]|(?:\([^\s()<>]+\)))*\))+'
-    r'(?:\((?:[^\s()<>]|(?:\([^\s()<>]+\)))*\)|'
-    r'[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))'
+# supported minimal url pattern:
+#   - http://domain.tld
+#   - https://domain.tld
+#   - sub.domain.tld
+#   - domain.tld/
+# custom ports are supported, however there is no port range check
+# parens in the path are matched balanced only:
+#   - me.you/(yeah) is matched as me.you/(yeah)
+#   - me.you/(nope)) is matched as me.you/(nope)
+#   this is useful when parsing a wrapped url: (inner.link/path_with_(parens))
+auto_link = r"""
+\b
+(
+    (?:
+        https?://
+        |
+        (?<!@)[a-zA-Z0-9\-]{1,63}\.
+        |
+        (?=\S+/)
+    )
+    (?:[a-zA-Z0-9\-]{1,63}\.)+
+    [a-zA-Z0-9\-]{2,63}
+    (?::\d+)?
+    \b(?!@)
+    (?:
+        /
+        (?:
+            \(
+                [^\s/()]*
+                \(
+                    [^\s/()]+
+                \)
+                [^\s/()]*
+            \)
+            |
+            \(
+                [^\s/()]+
+            \)
+            |
+            [^\s/(){};:!<>«»“”"'‘’`´]*
+        )*
+    )*
 )
+""".replace(' ', '').replace('\n', '')
 
 # Precompiled regex for matching protocol part of URL
 url_proto_regex = re.compile(r'(?i)^[a-z][\w-]+:/{1,3}')

--- a/hangups/test/test_message_parser.py
+++ b/hangups/test/test_message_parser.py
@@ -18,6 +18,119 @@ def test_parse_linebreaks():
     assert expected == parse_text(text)
 
 
+def test_parse_auto_link_minimal():
+    text = (
+        'http://domain.tld\n'
+        'https://domain.tld\n'
+        'sub.domain.tld\n'
+        'domain.tld/\n'
+    )
+    expected = [
+        ('http://domain.tld', {'link_target': 'http://domain.tld'}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('https://domain.tld', {'link_target': 'https://domain.tld'}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('sub.domain.tld', {'link_target': 'http://sub.domain.tld'}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('domain.tld/', {'link_target': 'http://domain.tld/'}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+    ]
+    assert expected == parse_text(text)
+
+
+def test_parse_auto_link_port():
+    text = (
+        'http://domain.tld:8080\n'
+        'https://domain.tld:8080\n'
+        'sub.domain.tld:8080\n'
+        'domain.tld:8080/\n'
+    )
+    expected = [
+        ('http://domain.tld:8080',
+         {'link_target': 'http://domain.tld:8080'}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('https://domain.tld:8080',
+         {'link_target': 'https://domain.tld:8080'}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('sub.domain.tld:8080',
+         {'link_target': 'http://sub.domain.tld:8080'}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('domain.tld:8080/',
+         {'link_target': 'http://domain.tld:8080/'}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+    ]
+    assert expected == parse_text(text)
+
+
+def test_parse_auto_link_parens():
+    text = (
+        'pre (https://domain.tld) post\n'
+        'pre (inner https://domain.tld inner) post\n'
+        'pre (inner (https://domain.tld) inner) post\n'
+        'pre https://domain.tld/path(inner) post\n'
+        'pre (https://domain.tld/path(inner)) post\n'
+    )
+    expected = [
+        ('pre (', {}),
+        ('https://domain.tld', {'link_target': 'https://domain.tld'}),
+        (') post', {}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('pre (inner ', {}),
+        ('https://domain.tld', {'link_target': 'https://domain.tld'}),
+        (' inner) post', {}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('pre (inner (', {}),
+        ('https://domain.tld', {'link_target': 'https://domain.tld'}),
+        (') inner) post', {}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('pre ', {}),
+        ('https://domain.tld/path(inner)',
+         {'link_target': 'https://domain.tld/path(inner)'}),
+        (' post', {}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('pre (', {}),
+        ('https://domain.tld/path(inner)',
+         {'link_target': 'https://domain.tld/path(inner)'}),
+        (') post', {}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+    ]
+    assert expected == parse_text(text)
+
+
+def test_parse_auto_link_email():
+    text = (
+        'name@domain.tld\n'
+        'name.other.name@domain.tld\n'
+        'name.other.name@sub.domain.tld\n'
+    )
+    expected = [
+        ('name@domain.tld', {}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('name.other.name@domain.tld', {}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('name.other.name@sub.domain.tld', {}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+    ]
+    assert expected == parse_text(text)
+
+
+def test_parse_auto_link_invalid():
+    text = (
+        'hangups:hangups\n'
+        'http://tld\n'
+        'http://tld/path\n'
+    )
+    expected = [
+        ('hangups:hangups', {}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('http://tld', {}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+        ('http://tld/path', {}),
+        ('\n', {'segment_type': hangouts_pb2.SEGMENT_TYPE_LINE_BREAK}),
+    ]
+    assert expected == parse_text(text)
+
+
 def test_parse_autolinks():
     text = ('www.google.com google.com/maps '
             '(https://en.wikipedia.org/wiki/Parenthesis_(disambiguation))')


### PR DESCRIPTION
Supported minimal url pattern:
  - http://domain.tld
  - https://domain.tld
  - sub.domain.tld
  - domain.tld/

Custom ports are supported, however there is no port range check.

Parens in the path are matched balanced only:
  - me.you/(yeah) is matched as me.you/(yeah)
  - me.you/(nope)) is matched as me.you/(nope)
  this is useful when parsing a wrapped url: (inner.link/path_with_(parens))

A visualization of the regex is available here: https://www.debuggex.com/r/D5aoLgWh95QV_VMT

Supersedes https://github.com/tdryer/hangups/pull/365