### PR TITLE
Add chat-archive to "Projects using hangups"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ Projects using hangups
 - `ovkulkarni/hangoutsbot`_: Google Hangouts Bot using SQL
 - `defund/pearl`_: Google Hangouts bot framework
 - `HangupsDroid`_: Unofficial Google Hangouts client for Android
+- `chat-archive`_: Easy to use offline chat archive
 
 .. _HangupsBot: https://github.com/xmikos/hangupsbot
 .. _Hubot Hangouts Adapter: https://github.com/groupby/hubot-hangups
@@ -71,6 +72,7 @@ Projects using hangups
 .. _ovkulkarni/hangoutsbot: https://github.com/ovkulkarni/hangoutsbot
 .. _defund/pearl: https://github.com/defund/pearl
 .. _HangupsDroid: https://github.com/Rudloff/hangupsdroid
+.. _chat-archive: https://github.com/xolox/python-chat-archive
 
 Related projects
 ----------------


### PR DESCRIPTION
**TL;DR:** This pull request adds a mention of [chat-archive](https://github.com/xolox/python-chat-archive) under "Projects using hangups" in the readme, as an example for developers wanting to integrate hangups and to give my project a tiny bit of exposure :innocent:.

**Background:** A few months ago I developed and published a Python program called [chat-archive](https://github.com/xolox/python-chat-archive) which uses `hangups` for its Google Hangouts backend. Before starting to work with `hangups` I spent weeks researching how to get at my archived chat messages stored on Google's servers (I knew the messages were there, I just had to find a practical way to get access) and eventually I ended up with two backends for my program:

1. A Google Talk backend that connects to Gmail over IMAP to download old (pre 2014) messages.
2. A Google Hangouts backend that uses `hangups` to download messages since 2014.

Thanks a lot for developing `hangups`! The fact that it was available when I was developing the [chat-archive](https://github.com/xolox/python-chat-archive) program was one of several reasons that convinced me to go ahead and publish my project :slightly_smiling_face:.