### PR TITLE
Add captcha support

### DIFF
--- a/hangups/auth.py
+++ b/hangups/auth.py
@@ -331,9 +331,9 @@ def _get_authorization_code(session, credentials_prompt):
             input_selector = PHONE_CODE_SELECTOR
         else:
             raise GoogleAuthError('Unknown verification code input')
-        verfification_code = credentials_prompt.get_verification_code()
+        verification_code = credentials_prompt.get_verification_code()
         browser.submit_form(
-            VERIFICATION_FORM_SELECTOR, {input_selector: verfification_code}
+            VERIFICATION_FORM_SELECTOR, {input_selector: verification_code}
         )
 
     try:


### PR DESCRIPTION
**Context:** As explained in #445 I integrated `hangups` in my [chat-archive](https://github.com/xolox/python-chat-archive) program a few months ago. Back then (August 2018) `hangups` worked fine for me, but a few weeks ago the authentication started failing and try as I might I could not get it to work again :slightly_frowning_face:.

**Disclaimer:** Initially I had assumed I'd done something stupid when integrating hangups (even though it had worked before) but using `python -m hangups.auth` helped to confirm that my authentication problems had nothing to do with the integration between `hangups` and [chat-archive](https://github.com/xolox/python-chat-archive).

**Analysis:**

- Tonight I decided to dive in and find out what was going wrong, which ended up with me in an interactive debugger stepping through `_get_authorization_code()` and dumping the response HTML to a temporary file so I could see what was going on :innocent:.
- I found out that after the password submission a captcha challenge was being presented. Because `hangups` didn't handle this response it failed to select the mandatory TOTP challenge and as a result the exception `hangups.auth.GoogleAuthError: Authorization code cookie not found` was raised.

**Resolution:**

- When I found out that the captcha challenge was to blame for my problems I resolved to create a pull request for `hangups` that would at the very least inform the user via logging that authentication was failing due to missing captcha support.
- A quick `pdb` session convinced me that it wouldn't be that hard to actually add support for captcha images instead of just logging a message, because I didn't see another reasonable<sup>[1]</sup> way to get `hangups` to successfully connect again.

<sup>[1]</sup> When I say "reasonable" I'm thinking about the potential audience of my [chat-archive](https://github.com/xolox/python-chat-archive) program, whom I'm not comfortable asking to open a `pdb` prompt or use the "Web Developer Tools" to extract a cookie from a browser session.

**Expectation management:**

I expect that `hangups` is used in a lot of different contexts (CLI, GUI, headless?) and I guess the `webbrowser.open()` call might be deemed inappropriate, however:

1. The `webbrowser.open()` call is located inside `CredentialsPrompt` so that this behavior can easily be overridden by extending.

2. The captcha image URL is logged so that the user can manually open it if the use of `webbrowser.open()` doesn't work.

3. AFAICT when the captcha challenge is presented there was formerly (before this pull request) no way for `hangups` to ever finish successfully, so in that sense backwards compatibility shouldn't be a concern.

If there's problems with my current implementation that need to be resolved before this can be merged, feel free to let me know, because I'd love to see this get merged. While this new functionality is likely to be fragile, right now it's definitely an added value for me :slightly_smiling_face:.