### PR TITLE
Proactively renew SID

### DIFF
--- a/hangups/channel.py
+++ b/hangups/channel.py
@@ -305,6 +305,8 @@ class Channel(object):
         except aiohttp.ServerDisconnectedError as err:
             raise exceptions.NetworkError(
                 'Server disconnected error: %s' % err)
+        except aiohttp.ClientPayloadError:
+            raise UnknownSIDError('SID is about to expire')
         except aiohttp.ClientError as err:
             raise exceptions.NetworkError('Request connection error: %s' % err)
 


### PR DESCRIPTION
This is a possible fix for #456 .

See the comments in the liked issue for details.

As there might be dropped messages while we renew the session, we should keep the log message on level `WARNING`.