### PR TITLE
Change the device name from "iOS"

### DIFF
--- a/hangups/auth.py
+++ b/hangups/auth.py
@@ -40,6 +40,7 @@ OAUTH2_LOGIN_URL = (
         urllib.parse.urlencode(dict(
             scope='+'.join(OAUTH2_SCOPES),
             client_id=OAUTH2_CLIENT_ID,
+            device_name='hangups',
         ), safe='+')
     )
 )


### PR DESCRIPTION
This Oauth flow results in a seemingly random iOS device show up on [myaccount.google.com](https://myaccount.google.com/security). This commit changes the name to indicate where that device came from.
![hangups](https://user-images.githubusercontent.com/3949892/52790409-c025a200-3066-11e9-8173-995fd76bb610.png)