### PR TITLE
Remove protobuf version cap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
     'readlike==0.1.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)
     'ReParser==1.4.3',
-    'protobuf>=3.1.0,<=3.6.1',
+    'protobuf>=3.1.0',
     'urwid==1.3.1',
     'MechanicalSoup==0.6.0',
 ]


### PR DESCRIPTION
Allows for the most up-to-date version to be used without breaking hangups.