### PR TITLE
Allow usage of protobuf v3.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
     'readlike==0.1.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)
     'ReParser==1.4.3',
-    'protobuf>=3.1.0,<=3.6.1',
+    'protobuf>=3.1.0,<=3.7.0',
     'urwid==1.3.1',
     'MechanicalSoup==0.6.0',
 ]


### PR DESCRIPTION
Well, same as #465, but set the version cap to current protobuf version instead.

Too bad I did not see the other pull request before as I would have use it to fix my hangup install.

Feel free to merge whichever pull request serve the project the best. Just submitting in case it can help speed up merge, so I can use hangups from source again :)

Thank you for maintaining this great project.