### PR TITLE
 Fix Conversation.get_events for cached events

### DIFF
--- a/examples/get_events.py
+++ b/examples/get_events.py
@@ -1,0 +1,52 @@
+"""Example of using hangups to get conversation events."""
+
+import hangups
+
+from common import run_example
+
+
+MAX_REQUESTS = 3
+MAX_EVENTS = 5
+
+
+async def get_events(client, args):
+    _, conversation_list = await hangups.build_user_conversation_list(client)
+
+    try:
+        conversation = conversation_list.get(args.conversation_id)
+    except KeyError:
+        print('conversation {!r} not found'.format(args.conversation_id))
+        return
+
+    # Load events from the server
+    all_events = await _get_events(conversation)
+    # Load events cached in the conversation
+    all_events_cached = await _get_events(conversation)
+
+    assert (
+        [event.timestamp for event in all_events] ==
+        [event.timestamp for event in all_events_cached]
+    )
+
+    # Print the events oldest to newest
+    for event in all_events:
+        print('{} {} {!r}'.format(
+            event.timestamp.strftime('%c'), event.__class__.__name__,
+            getattr(event, 'text')
+        ))
+
+
+async def _get_events(conversation):
+    all_events = []  # newest-first
+    event_id = None
+    for _ in range(MAX_REQUESTS):
+        events = await conversation.get_events(
+            event_id=event_id, max_events=MAX_EVENTS
+        )
+        event_id = events[0].id_  # oldest event
+        all_events.extend(reversed(events))
+    return list(reversed(all_events))  # oldest-first
+
+
+if __name__ == '__main__':
+    run_example(get_events, '--conversation-id')

--- a/hangups/conversation.py
+++ b/hangups/conversation.py
@@ -622,7 +622,7 @@ class Conversation(object):
 
         Returns:
             List of :class:`.ConversationEvent` instances, ordered
-            newest-first.
+            oldest-first.
 
         Raises:
             KeyError: If ``event_id`` does not correspond to a known event.
@@ -638,7 +638,10 @@ class Conversation(object):
             # oldest event we have.
             conv_event = self.get_event(event_id)
             if self._events[0].id_ != event_id:
-                conv_events = self._events[self._events.index(conv_event) + 1:]
+                # Return at most max_events events preceding the event at this
+                # index.
+                index = self._events.index(conv_event)
+                conv_events = self._events[max(index - max_events, 0):index]
             else:
                 logger.info('Loading events for conversation {} before {}'
                             .format(self.id_, conv_event.timestamp))


### PR DESCRIPTION
When retrieving events that were previously loaded, `Conversation.get_events` was returning events newer than the provided event ID rather than older.


Also, add an example for `Conversation.get_events`.