### PR TITLE
[user] extend default user detection

### DIFF
--- a/hangups/test/test_user.py
+++ b/hangups/test/test_user.py
@@ -1,0 +1,101 @@
+"""Tests for the user module"""
+
+
+import hangups.user
+import hangups.hangouts_pb2
+
+
+USER_ID = hangups.user.UserID(1, 1)
+
+
+def test_default_type_detection_empty_0():
+    # missing names
+    user = hangups.user.User(
+        USER_ID,
+        full_name='',
+        first_name='',
+        photo_url='',
+        emails=[],
+        is_self=False,
+    )
+
+    assert user.full_name == hangups.user.DEFAULT_NAME
+    assert user.first_name == hangups.user.DEFAULT_NAME
+    assert user.name_type == hangups.user.NameType.DEFAULT
+
+
+def test_default_type_detection_empty_1():
+    # missing names
+    user = hangups.user.User(
+        USER_ID,
+        full_name=None,
+        first_name=None,
+        photo_url='',
+        emails=[],
+        is_self=False,
+    )
+
+    assert user.full_name == hangups.user.DEFAULT_NAME
+    assert user.first_name == hangups.user.DEFAULT_NAME
+    assert user.name_type == hangups.user.NameType.DEFAULT
+
+
+def test_default_type_detection_from_conv_part_data():
+    # default user in 201904
+    conv_part_data = hangups.hangouts_pb2.ConversationParticipantData(
+        id=hangups.hangouts_pb2.ParticipantId(
+            chat_id='1',
+            gaia_id='1'
+        ),
+        fallback_name='unknown',
+        invitation_status=hangups.hangouts_pb2.INVITATION_STATUS_ACCEPTED,
+        participant_type=hangups.hangouts_pb2.PARTICIPANT_TYPE_GAIA,
+        new_invitation_status=hangups.hangouts_pb2.INVITATION_STATUS_ACCEPTED,
+    )
+
+    user = hangups.user.User.from_conv_part_data(
+        conv_part_data=conv_part_data,
+        self_user_id=USER_ID
+    )
+
+    assert user.full_name == hangups.user.DEFAULT_NAME
+    assert user.first_name == hangups.user.DEFAULT_NAME
+    assert user.name_type == hangups.user.NameType.DEFAULT
+
+
+def test_real_type():
+    # regular name
+    user = hangups.user.User(
+        USER_ID,
+        full_name='Joe Doe',
+        first_name='Joe',
+        photo_url='',
+        emails=[],
+        is_self=False,
+    )
+
+    assert user.full_name == 'Joe Doe'
+    assert user.first_name == 'Joe'
+    assert user.name_type == hangups.user.NameType.REAL
+
+
+def test_real_type_from_conv_part_data():
+    conv_part_data = hangups.hangouts_pb2.ConversationParticipantData(
+        id=hangups.hangouts_pb2.ParticipantId(
+            chat_id='1',
+            gaia_id='1'
+        ),
+        fallback_name='Joe Doe',
+        invitation_status=hangups.hangouts_pb2.INVITATION_STATUS_ACCEPTED,
+        participant_type=hangups.hangouts_pb2.PARTICIPANT_TYPE_GAIA,
+        new_invitation_status=hangups.hangouts_pb2.INVITATION_STATUS_ACCEPTED,
+    )
+
+    user = hangups.user.User.from_conv_part_data(
+        conv_part_data=conv_part_data,
+        self_user_id=USER_ID
+    )
+
+    assert user.full_name == 'Joe Doe'
+    assert user.first_name == 'Joe'
+    assert user.name_type == hangups.user.NameType.REAL

--- a/hangups/user.py
+++ b/hangups/user.py
@@ -113,7 +113,11 @@ class User(object):
         """
         user_id = UserID(chat_id=conv_part_data.id.chat_id,
                          gaia_id=conv_part_data.id.gaia_id)
-        return User(user_id, conv_part_data.fallback_name, None, None, [],
+        if conv_part_data.fallback_name == 'unknown':
+            full_name = None
+        else:
+            full_name = conv_part_data.fallback_name
+        return User(user_id, full_name, None, None, [],
                     (self_user_id == user_id) or (self_user_id is None))
 
 

--- a/hangups/user.py
+++ b/hangups/user.py
@@ -39,7 +39,6 @@ class User(object):
             first_name = full_name
             name_type = NameType.NUMERIC
         else:
-            full_name = full_name if full_name else DEFAULT_NAME
             first_name = first_name if first_name else full_name.split()[0]
             name_type = NameType.REAL
 


### PR DESCRIPTION
Probably with the latest deprecation of G+ I am seeing users without proper names in the initial user list.

Their display name and first name is 'unknown'.

To stop them from updating a downstream cache I am proposing to flag them as default upstream.

I added some test cases to show / lock the behavior.