### PR TITLE
Show message instead of crash on invalid image path

### DIFF
--- a/hangups/ui/__main__.py
+++ b/hangups/ui/__main__.py
@@ -936,7 +936,12 @@ class ConversationWidget(WidgetBase):
         elif text.startswith('/image') and len(text.split(' ')) == 2:
             # Temporary UI for testing image uploads
             filename = text.split(' ')[1]
-            image_file = open(filename, 'rb')
+            try:
+                image_file = open(filename, 'rb')
+            except FileNotFoundError:
+                message = 'Failed to find image {}'.format(filename)
+                self._status_widget.show_message(message)
+                return
             text = ''
         else:
             image_file = None


### PR DESCRIPTION
This PR prevents hangups from crashing when the user inputs `/image /path/to/image` where `/path/to/image` does not exist. 

Instead of crashing, the message `"Failed to find image /path/to/image"` is shown.