### PR TITLE
Add canonical_email to user.User

### DIFF
--- a/hangups/test/test_user.py
+++ b/hangups/test/test_user.py
@@ -15,6 +15,7 @@ def test_default_type_detection_empty_0():
         full_name='',
         first_name='',
         photo_url='',
+        canonical_email='',
         emails=[],
         is_self=False,
     )
@@ -31,6 +32,7 @@ def test_default_type_detection_empty_1():
         full_name=None,
         first_name=None,
         photo_url='',
+        canonical_email='',
         emails=[],
         is_self=False,
     )
@@ -70,6 +72,7 @@ def test_real_type():
         full_name='Joe Doe',
         first_name='Joe',
         photo_url='',
+        canonical_email='',
         emails=[],
         is_self=False,
     )

--- a/hangups/user.py
+++ b/hangups/user.py
@@ -28,8 +28,8 @@ class User:
     instances of this class.
     """
 
-    def __init__(self, user_id, full_name, first_name, photo_url, emails,
-                 is_self):
+    def __init__(self, user_id, full_name, first_name, photo_url,
+                 canonical_email, emails, is_self):
         # Handle full_name or first_name being None by creating an approximate
         # first_name from the full_name, or setting both to DEFAULT_NAME.
         if not full_name:
@@ -57,8 +57,11 @@ class User:
         self.photo_url = photo_url
         """The user's profile photo URL (:class:`str`)."""
 
-        self.emails = emails
+        self.canonical_email = canonical_email
         """The user's email address (:class:`str`)."""
+
+        self.emails = emails
+        """The user's other Google Contacts email addresses (:class:`str`)."""
 
         self.is_self = is_self
         """Whether this user is the current user (:class:`bool`)."""
@@ -96,6 +99,7 @@ class User:
         return User(user_id, entity.properties.display_name,
                     entity.properties.first_name,
                     entity.properties.photo_url,
+                    entity.properties.canonical_email,
                     entity.properties.email,
                     (self_user_id == user_id) or (self_user_id is None))
 
@@ -117,7 +121,7 @@ class User:
             full_name = None
         else:
             full_name = conv_part_data.fallback_name
-        return User(user_id, full_name, None, None, [],
+        return User(user_id, full_name, None, None, [], None,
                     (self_user_id == user_id) or (self_user_id is None))
 
 
@@ -172,7 +176,7 @@ class UserList:
         except KeyError:
             logger.warning('UserList returning unknown User for UserID %s',
                            user_id)
-            return User(user_id, None, None, None, [], False)
+            return User(user_id, None, None, None, [], None, False)
 
     def get_all(self):
         """Get all known users.


### PR DESCRIPTION
I was looking for something immutable for each user (for https://github.com/tulir/mautrix-hangouts/issues/43).
I was hoping i could get the user's proper email address.

Looks like user.User.emails is not really very reliable, it's simply a
collection of email addresses it found in Google Contacts. I tried this
experimentally: changing google contacts to something bogus yielded weird
results to this array. I changed this

By doing a print(repr(entity)) in User.from_entity I noticed the entity
had another cool property: canonical_email
So I added is as another attribute of the User class.