### PR TITLE
Fix order of email parameters to User constructor

### DIFF
--- a/hangups/user.py
+++ b/hangups/user.py
@@ -121,7 +121,7 @@ class User:
             full_name = None
         else:
             full_name = conv_part_data.fallback_name
-        return User(user_id, full_name, None, None, [], None,
+        return User(user_id, full_name, None, None, None, [],
                     (self_user_id == user_id) or (self_user_id is None))
 
 
@@ -176,7 +176,7 @@ class UserList:
         except KeyError:
             logger.warning('UserList returning unknown User for UserID %s',
                            user_id)
-            return User(user_id, None, None, None, [], None, False)
+            return User(user_id, None, None, None, None, [], False)
 
     def get_all(self):
         """Get all known users.


### PR DESCRIPTION
#510 added `canonical_email` to `User` objects:

https://github.com/tdryer/hangups/blob/84f2dbcd795e7fe97ecb4766622620c0aa6e682c/hangups/user.py#L31-L32

...but the default assignments of that and `emails` are the wrong way around in some cases (`[], None` should be `None, []`):

https://github.com/tdryer/hangups/blob/84f2dbcd795e7fe97ecb4766622620c0aa6e682c/hangups/user.py#L124-L125

https://github.com/tdryer/hangups/blob/84f2dbcd795e7fe97ecb4766622620c0aa6e682c/hangups/user.py#L179