### PR TITLE
Allow usage of protobuf 3.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     'readlike>=0.1.2,<0.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)
     'ReParser==1.4.3',
-    'protobuf>=3.1.0,<3.16',
+    'protobuf>=3.1.0,<3.17',
     'urwid>=1.3.1,<2.2',
     'MechanicalSoup>=0.6.0,<0.13',
 ]


### PR DESCRIPTION
And another bump in version for protobuf. This works well for me with the latest protobuf update.