### PR TITLE
Remove staticmethod decorator from CredentailsPrompt methods

### DIFF
--- a/hangups/auth.py
+++ b/hangups/auth.py
@@ -93,8 +93,7 @@ class CredentialsPrompt:
     This implementation prompts the user in a terminal using standard in/out.
     """
 
-    @staticmethod
-    def get_email():
+    def get_email(self):  # pylint: disable=no-self-use
         """Prompt for email.
 
         Returns:
@@ -103,8 +102,7 @@ class CredentialsPrompt:
         print('Sign in with your Google account:')
         return input('Email: ')
 
-    @staticmethod
-    def get_password():
+    def get_password(self):  # pylint: disable=no-self-use
         """Prompt for password.
 
         Returns:
@@ -112,8 +110,7 @@ class CredentialsPrompt:
         """
         return getpass.getpass()
 
-    @staticmethod
-    def get_verification_code():
+    def get_verification_code(self):  # pylint: disable=no-self-use
         """Prompt for verification code.
 
         Returns:
@@ -121,8 +118,7 @@ class CredentialsPrompt:
         """
         return input('Verification code: ')
 
-    @staticmethod
-    def get_authorization_code():
+    def get_authorization_code(self):  # pylint: disable=no-self-use
         """Prompt for authorization code.
 
         Returns:


### PR DESCRIPTION
I would like to suggest the removal of the `@staticmethod` decorators for `CredentialPrompt` methods.

The `CredentialsPrompt.get_*` methods aren't really staticmethods, they just don't use `self`.
Each invocation happens from an existing instance with `credentials_prompt.get_*`.

Furthermore, it's reasonable to subclass `CredentialsPrompt` and then provide `email`, `pwd`, and credentials in `__init__`. Doing so with the `@staticmethod` decorator is still possible, but with the next pylint release `2.13` it will be an error as technically it's a different function signature.
An example from Home Assistant: [hangouts/hangups_utils.py#L10-L70](https://github.com/home-assistant/core/blob/489d85d862789523788bcc539a2701400052ae26/homeassistant/components/hangouts/hangups_utils.py#L10-L70).


In theory this could be a breaking change for someone who relied on calling these with `CredentialsPrompt.get_*`, I'm not familiar enough with the library to know if that's a real problem.