### PR TITLE
Allow async-timeout v4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('README.rst') as f:
 install_requires = [
     'ConfigArgParse>=0.11.0,<2',
     'aiohttp>=3.7,<4',
-    'async-timeout>=2,<4',
+    'async-timeout>=2,<5',
     'appdirs>=1.4,<1.5',
     'readlike>=0.1.2,<0.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)


### PR DESCRIPTION
Bump upper limit for `async-timeout` dependency.

From what I can tell, the library should still work with `async-timeout` v4. I've linked the Changelog and diff below. The breaking changes were that two properties have been removed: `timeout.remaining`, and `timeout.timeout`. Both aren't used here.

https://github.com/aio-libs/async-timeout/blob/master/CHANGES.rst#400-2021-11-01
https://github.com/aio-libs/async-timeout/compare/v3.0.1...v4.0.1