### PR TITLE
Bump protobuf version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     'readlike>=0.1.2,<0.2',
     'requests>=2.6.0,<3',  # uses semantic versioning (after 2.6)
     'ReParser==1.4.3',
-    'protobuf>=3.1.0,<3.20',
+    'protobuf>=3.1.0,<4',
     'urwid>=1.3.1,<2.2',
     'MechanicalSoup>=0.6.0,<0.13',
 ]


### PR DESCRIPTION
Bump upper limit for `protobuf` to `<4`.

Protobuf version `3.20.0` was uploaded to PyPI yesterday which causes a dependency conflict with `hangups`.
AFAICT `3.20.0` is still compatible, they only dropped support for Python < 3.7. That however isn't an issue as pip can resolve that and choose `3.19` for Python 3.6.

https://github.com/protocolbuffers/protobuf/releases/tag/v3.20.0

--
Related: https://github.com/home-assistant/core/pull/69112

